### PR TITLE
refactor: centralize file and directory filtering logic

### DIFF
--- a/lsp-server/src/scanner.rs
+++ b/lsp-server/src/scanner.rs
@@ -14,16 +14,32 @@ const EXCLUDED_DIRS: &[&str] = &[
     "gen",
 ];
 
+/// Ignored files list
+const EXCLUDED_FILES: &[&str] = &["vite.config.ts"];
+
+/// Ignored file suffixes list
+const EXCLUDED_FILE_SUFFIXES: &[&str] = &[".d.ts"];
+
 /// List of extensions that are supported by extensions
 const TARGET_EXTENSIONS: &[&str] = &["rs", "ts", "tsx", "js", "jsx", "vue"];
 
-/// Filter: Returns true if this is a folder to be IGNORED
-fn is_ignored_dir(entry: &DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .map(|s| EXCLUDED_DIRS.contains(&s))
-        .unwrap_or(false)
+/// Filter: Returns true if this is a folder or file to be IGNORED
+fn should_skip(entry: &DirEntry) -> bool {
+    let name = entry.file_name().to_str().unwrap_or("");
+
+    if entry.file_type().is_dir() {
+        EXCLUDED_DIRS.contains(&name)
+    } else {
+        let name_lc = name.to_lowercase();
+
+        let is_excluded_file = EXCLUDED_FILES.contains(&name);
+
+        let is_excluded_suffix = EXCLUDED_FILE_SUFFIXES
+            .iter()
+            .any(|suffix| name_lc.ends_with(suffix));
+
+        is_excluded_file || is_excluded_suffix
+    }
 }
 
 /// Make sure it is a Tauri project by searching for the configuration file
@@ -31,14 +47,17 @@ pub fn is_tauri_project(root: &Path) -> bool {
     WalkDir::new(root)
         .follow_links(false) // Avoid symlinks for security and speed
         .into_iter()
-        .filter_entry(|e| !is_ignored_dir(e))
+        .filter_entry(|e| !should_skip(e))
         .filter_map(|e| e.ok()) // Ignoring file access errors
         .any(|e| {
-            if let Some(name) = e.file_name().to_str() {
-                // https://v2.tauri.app/reference/config/#file-formats
-                return name.to_lowercase().starts_with("tauri");
+            if !e.file_type().is_file() {
+                return false;
             }
-            false
+
+            e.file_name()
+                .to_str()
+                .map(|name| name.to_lowercase().starts_with("tauri")) // https://v2.tauri.app/reference/config/#file-formats
+                .unwrap_or(false)
         })
 }
 
@@ -47,28 +66,18 @@ pub fn is_tauri_project(root: &Path) -> bool {
 pub fn scan_workspace_files(root: &Path) -> Vec<PathBuf> {
     WalkDir::new(root)
         .into_iter()
-        .filter_entry(|e| !is_ignored_dir(e))
+        .filter_entry(|e| !should_skip(e))
         .filter_map(|e| e.ok())
         .filter(|e| {
             if !e.file_type().is_file() {
                 return false;
             }
 
-            let path = e.path();
-
-            // Exclude vite.config.ts
-            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name == "vite.config.ts" {
-                    return false;
-                }
-            }
-
-            // Check the extension
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                return TARGET_EXTENSIONS.contains(&ext);
-            }
-
-            false
+            e.path()
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| TARGET_EXTENSIONS.contains(&ext))
+                .unwrap_or(false)
         })
         .map(|e| e.into_path())
         .collect()


### PR DESCRIPTION
- The logic for ignoring folders is combined with file checking into `should_skip`. 
- Added filtering of declarative files *.d.ts and vite.config.ts. 
- Cleaned up `scan_workspace_files` and `is_tauri_project` code from unnecessary checks.
Closes #17 