### PR TITLE
fix(vscode): restrict referenceLimit to non-negative integers

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -44,6 +44,7 @@
           "type": "integer",
           "default": 3,
           "description": "The maximum number of individual file links to show in CodeLens before summarizing them (e.g., '5 references').",
+          "minimum": 0,
           "scope": "resource"
         }
       }


### PR DESCRIPTION
Update the configuration schema in package.json to enforce a minimum value of 0 for `tarus.referenceLimit`. This prevents invalid negative input (e.g. -12) in the settings UI.