### PR TITLE
fix(lsp): correctly identify standalone Specta as Specta and parse types

### DIFF
--- a/lsp-server/src/bindings_reader.rs
+++ b/lsp-server/src/bindings_reader.rs
@@ -33,9 +33,10 @@ fn setup_ts_query(content: &str, query_str: &str) -> Option<(tree_sitter::Tree, 
 /// inside an `export const commands = { ... }` block.
 #[must_use]
 pub fn parse_specta_bindings(content: &str, source_path: &Path) -> Vec<CommandSchema> {
-    let Some((tree, query)) =
-        setup_ts_query(content, include_str!("queries/bindings_specta_commands.scm"))
-    else {
+    let Some((tree, query)) = setup_ts_query(
+        content,
+        include_str!("queries/bindings_specta_commands.scm"),
+    ) else {
         return Vec::new();
     };
 
@@ -151,24 +152,15 @@ fn unwrap_return_type_node(node: tree_sitter::Node<'_>, content: &str) -> String
         .to_string()
 }
 
-/// Parse a ts-rs generated file and return a map of `TypeName -> definition`.
-///
-/// Looks for lines like:
-/// ```text
-/// export type UserProfile = { id: number; name: string };
-/// ```
-#[must_use]
-pub fn parse_ts_rs_types(content: &str) -> HashMap<String, String> {
-    parse_type_aliases_and_interfaces(content, false)
-}
-
-/// Parse a typegen-generated file and return a map of `TypeName -> definition`.
+/// Parse a TypeScript bindings file and return a map of `TypeName -> definition`.
 ///
 /// Handles both:
-/// - `export type Name = ...;`  (inline type aliases)
-/// - `export interface Name { field: type; ... }` (multi-line interface blocks)
+/// - `export type Name = ...;` (type aliases)
+/// - `export interface Name { ... }` (interfaces)
+///
+/// This is a unified parser used by Specta, ts-rs, and tauri-typegen.
 #[must_use]
-pub fn parse_typegen_types(content: &str) -> HashMap<String, String> {
+pub fn parse_typescript_types(content: &str) -> HashMap<String, String> {
     parse_type_aliases_and_interfaces(content, true)
 }
 

--- a/lsp-server/src/capabilities/completion.rs
+++ b/lsp-server/src/capabilities/completion.rs
@@ -42,7 +42,8 @@ pub fn handle_completion(
         .or_else(|| std::fs::read_to_string(&path).ok())?;
 
     let lines: Vec<&str> = content.lines().collect();
-    let line_idx = usize::try_from(params.text_document_position.position.line).unwrap_or(usize::MAX);
+    let line_idx =
+        usize::try_from(params.text_document_position.position.line).unwrap_or(usize::MAX);
     if line_idx >= lines.len() {
         return None;
     }

--- a/lsp-server/src/capabilities/diagnostics.rs
+++ b/lsp-server/src/capabilities/diagnostics.rs
@@ -158,7 +158,10 @@ fn compute_structural_diagnostics(
             if is_unused {
                 Some((
                     DiagnosticSeverity::WARNING,
-                    format!("{entity_label} '{}' is defined but never {usage_label}", key.name),
+                    format!(
+                        "{entity_label} '{}' is defined but never {usage_label}",
+                        key.name
+                    ),
                 ))
             } else {
                 None
@@ -249,8 +252,7 @@ fn check_param_keys(
     // BTreeSet gives deterministic ordering for diagnostic messages
     let expected: std::collections::BTreeSet<&str> =
         schema.params.iter().map(|p| p.name.as_str()).collect();
-    let actual: std::collections::BTreeSet<&str> =
-        call_keys.iter().map(String::as_str).collect();
+    let actual: std::collections::BTreeSet<&str> = call_keys.iter().map(String::as_str).collect();
 
     // Missing required params (present in schema, absent in call)
     let missing: Vec<&str> = expected.difference(&actual).copied().collect();

--- a/lsp-server/src/config_reader.rs
+++ b/lsp-server/src/config_reader.rs
@@ -144,13 +144,8 @@ fn match_specta_patterns(
 
         if ext_ok {
             let resolved = normalize_path(&src_tauri_dir.join(path_str));
-            let kind = if method == SPECTA_EXPORT_METHOD {
-                GeneratorKind::Specta
-            } else {
-                GeneratorKind::TsRs
-            };
             out.push(DiscoveredGenerator {
-                kind,
+                kind: GeneratorKind::Specta,
                 output_path: resolved,
                 is_directory: false,
             });
@@ -453,7 +448,7 @@ mod tests {
             &[
                 (GeneratorKind::Specta, "src/admin.ts"),
                 (GeneratorKind::Specta, "src/client.ts"),
-                (GeneratorKind::TsRs, "src/shared.ts"),
+                (GeneratorKind::Specta, "src/shared.ts"),
             ],
         );
     }
@@ -467,7 +462,7 @@ mod tests {
                 "src/main.rs",
                 r#"use specta_typescript::Typescript; fn main() { Typescript::default().export_to("../src/bindings.ts", &types); }"#,
             )],
-            &[(GeneratorKind::TsRs, "src/bindings.ts")],
+            &[(GeneratorKind::Specta, "src/bindings.ts")],
         );
     }
 

--- a/lsp-server/src/constants.rs
+++ b/lsp-server/src/constants.rs
@@ -42,9 +42,9 @@ pub const PRIORITY_DEFAULT: u8 = 50;
 // Specta/ts-rs discovery method names
 // ---------------------------------------------------------------------------
 
-/// `specta_typescript` export method name (standalone specta-typescript crate)
-pub const SPECTA_EXPORT_METHOD: &str = "export";
 /// `tauri-specta` export method name
+pub const SPECTA_EXPORT_METHOD: &str = "export";
+/// `specta_typescript` export method name (standalone specta-typescript crate)
 pub const SPECTA_EXPORT_TO_METHOD: &str = "export_to";
 /// Specta bindings variable name in generated TS
 pub const SPECTA_COMMANDS_VAR: &str = "commands";

--- a/lsp-server/src/file_processor.rs
+++ b/lsp-server/src/file_processor.rs
@@ -125,6 +125,10 @@ fn process_bindings_file(
             for schema in bindings_reader::parse_specta_events(content, &path_buf) {
                 project_index.add_event_schema(schema);
             }
+
+            for (name, def) in bindings_reader::parse_ts_rs_types(content) {
+                project_index.add_type_alias(name, def, path.to_path_buf());
+            }
         }
 
         GeneratorKind::TsRs => {

--- a/lsp-server/src/file_processor.rs
+++ b/lsp-server/src/file_processor.rs
@@ -126,19 +126,19 @@ fn process_bindings_file(
                 project_index.add_event_schema(schema);
             }
 
-            for (name, def) in bindings_reader::parse_ts_rs_types(content) {
+            for (name, def) in bindings_reader::parse_typescript_types(content) {
                 project_index.add_type_alias(name, def, path.to_path_buf());
             }
         }
 
         GeneratorKind::TsRs => {
-            for (name, def) in bindings_reader::parse_ts_rs_types(content) {
+            for (name, def) in bindings_reader::parse_typescript_types(content) {
                 project_index.add_type_alias(name, def, path.to_path_buf());
             }
         }
 
         GeneratorKind::Typegen => {
-            for (name, def) in bindings_reader::parse_typegen_types(content) {
+            for (name, def) in bindings_reader::parse_typescript_types(content) {
                 project_index.add_type_alias(name, def, path.to_path_buf());
             }
 

--- a/lsp-server/src/indexer/cache.rs
+++ b/lsp-server/src/indexer/cache.rs
@@ -3,8 +3,8 @@
 use crate::syntax::{Behavior, EntityType};
 
 use super::types::{DiagnosticInfo, IndexKey, LocationInfo, NameLocation};
-use std::sync::Arc;
 use super::ProjectIndex;
+use std::sync::Arc;
 
 impl ProjectIndex {
     /// Get all known names for a specific entity type (for completion)

--- a/lsp-server/src/indexer/reports.rs
+++ b/lsp-server/src/indexer/reports.rs
@@ -75,7 +75,12 @@ impl ProjectIndex {
             let locs = entry.value();
             let _ = writeln!(report_message, "  {key:?} ({} loc(s))", locs.len());
             for loc in locs {
-                let _ = writeln!(report_message, "    - {} {:?}", loc.path.display(), loc.range);
+                let _ = writeln!(
+                    report_message,
+                    "    - {} {:?}",
+                    loc.path.display(),
+                    loc.range
+                );
             }
         }
 
@@ -86,7 +91,12 @@ impl ProjectIndex {
             report_message.push_str("   (File Map is Empty)\n");
         } else {
             for entry in &self.file_map {
-                let _ = writeln!(report_message, "  {} ({} key(s))", entry.key().display(), entry.value().len());
+                let _ = writeln!(
+                    report_message,
+                    "  {} ({} key(s))",
+                    entry.key().display(),
+                    entry.value().len()
+                );
                 for k in entry.value() {
                     let _ = writeln!(report_message, "    - {k:?}");
                 }

--- a/lsp-server/src/indexer/schemas.rs
+++ b/lsp-server/src/indexer/schemas.rs
@@ -97,6 +97,9 @@ mod tests {
 
         index.remove_type_aliases_for_file(&path);
 
-        assert!(!index.type_aliases.contains_key("UserProfile"), "Alias should be removed");
+        assert!(
+            !index.type_aliases.contains_key("UserProfile"),
+            "Alias should be removed"
+        );
     }
 }

--- a/lsp-server/src/main.rs
+++ b/lsp-server/src/main.rs
@@ -114,7 +114,8 @@ impl Backend {
 
         if let Some(settings) = iter.next() {
             if let Some(is_enabled) = settings.as_bool() {
-                self.is_developer_mode_active.store(is_enabled, Ordering::Relaxed);
+                self.is_developer_mode_active
+                    .store(is_enabled, Ordering::Relaxed);
                 self.client
                     .log_message(
                         MessageType::INFO,
@@ -145,12 +146,13 @@ impl Backend {
         let is_dev_mode = self.is_developer_mode_active.clone();
 
         tokio::spawn(async move {
-            client.log_message(MessageType::INFO, "🚀 Starting background indexing...").await;
+            client
+                .log_message(MessageType::INFO, "🚀 Starting background indexing...")
+                .await;
 
-            let files =
-                tokio::task::spawn_blocking(move || scan_workspace_files(&root))
-                    .await
-                    .unwrap_or_default();
+            let files = tokio::task::spawn_blocking(move || scan_workspace_files(&root))
+                .await
+                .unwrap_or_default();
 
             for path in files {
                 file_processor::process_file_index(path, &project_index);
@@ -168,7 +170,9 @@ impl Backend {
                 client.log_message(MessageType::INFO, report).await;
             }
 
-            client.log_message(MessageType::INFO, "🏁 Indexing complete".to_string()).await;
+            client
+                .log_message(MessageType::INFO, "🏁 Indexing complete".to_string())
+                .await;
         });
     }
 }
@@ -229,10 +233,11 @@ impl LanguageServer for Backend {
         };
 
         let root_for_generators = root.clone();
-        let generators =
-            tokio::task::spawn_blocking(move || config_reader::discover_generators(&root_for_generators))
-                .await
-                .unwrap_or_default();
+        let generators = tokio::task::spawn_blocking(move || {
+            config_reader::discover_generators(&root_for_generators)
+        })
+        .await
+        .unwrap_or_default();
 
         if generators.is_empty() {
             self.client
@@ -299,7 +304,8 @@ impl LanguageServer for Backend {
 
         let result = capabilities::references::handle_references(params, &self.project_index);
 
-        self.log_dev_result(result.as_ref().map(Vec::len), "references").await;
+        self.log_dev_result(result.as_ref().map(Vec::len), "references")
+            .await;
 
         Ok(result)
     }
@@ -312,7 +318,8 @@ impl LanguageServer for Backend {
 
         let result = capabilities::code_lens::handle_code_lens(params, &self.project_index);
 
-        self.log_dev_result(result.as_ref().map(Vec::len), "code lenses").await;
+        self.log_dev_result(result.as_ref().map(Vec::len), "code lenses")
+            .await;
 
         Ok(result)
     }
@@ -329,7 +336,8 @@ impl LanguageServer for Backend {
 
         let result = capabilities::hover::handle_hover(params, &self.project_index);
 
-        self.log_dev_result(result.as_ref().map(|_| 1), "hover tooltip").await;
+        self.log_dev_result(result.as_ref().map(|_| 1), "hover tooltip")
+            .await;
 
         Ok(result)
     }
@@ -351,7 +359,8 @@ impl LanguageServer for Backend {
             workspace_root.as_ref(),
         );
 
-        self.log_dev_result(result.as_ref().map(Vec::len), "code actions").await;
+        self.log_dev_result(result.as_ref().map(Vec::len), "code actions")
+            .await;
 
         Ok(result)
     }
@@ -400,8 +409,11 @@ impl LanguageServer for Backend {
             &self.document_cache,
         );
 
-        self.log_dev_result(result.as_ref().map(completion_response_len), "completion items")
-            .await;
+        self.log_dev_result(
+            result.as_ref().map(completion_response_len),
+            "completion items",
+        )
+        .await;
 
         Ok(result)
     }

--- a/lsp-server/src/rust_type_extractor.rs
+++ b/lsp-server/src/rust_type_extractor.rs
@@ -39,10 +39,14 @@ pub fn rust_type_to_ts(rust_type: &str) -> String {
         RustType::Unit => "void".to_string(),
         RustType::Result => extract_first_generic_arg_from_type(t)
             .map_or_else(|| t.to_string(), |ok| rust_type_to_ts(&ok)),
-        RustType::Option => extract_first_generic_arg_from_type(t)
-            .map_or_else(|| t.to_string(), |inner| format!("{} | null", rust_type_to_ts(&inner))),
-        RustType::Vec => extract_first_generic_arg_from_type(t)
-            .map_or_else(|| t.to_string(), |inner| format!("{}[]", rust_type_to_ts(&inner))),
+        RustType::Option => extract_first_generic_arg_from_type(t).map_or_else(
+            || t.to_string(),
+            |inner| format!("{} | null", rust_type_to_ts(&inner)),
+        ),
+        RustType::Vec => extract_first_generic_arg_from_type(t).map_or_else(
+            || t.to_string(),
+            |inner| format!("{}[]", rust_type_to_ts(&inner)),
+        ),
         RustType::Other => t.to_string(),
     }
 }
@@ -60,8 +64,8 @@ enum RustType {
 
 fn classify_rust_type(t: &str) -> RustType {
     match t {
-        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64"
-        | "i128" | "isize" | "f32" | "f64" => RustType::Number,
+        "u8" | "u16" | "u32" | "u64" | "u128" | "usize" | "i8" | "i16" | "i32" | "i64" | "i128"
+        | "isize" | "f32" | "f64" => RustType::Number,
         "String" | "&str" => RustType::Str,
         "bool" => RustType::Bool,
         "()" => RustType::Unit,
@@ -292,10 +296,7 @@ fn try_extract_event_schemas_from_node(
 /// - Boolean literal → "boolean"
 /// - Struct expression → extract struct name
 /// - Variable reference → look up in function params, then local `let` bindings
-fn resolve_emit_payload_type(
-    node: tree_sitter::Node<'_>,
-    content: &str,
-) -> Option<String> {
+fn resolve_emit_payload_type(node: tree_sitter::Node<'_>, content: &str) -> Option<String> {
     let text = node.utf8_text(content.as_bytes()).ok()?;
 
     match node.kind() {

--- a/lsp-server/src/tree_parser/frontend_parser.rs
+++ b/lsp-server/src/tree_parser/frontend_parser.rs
@@ -134,8 +134,7 @@ pub(super) fn parse_frontend(
     let mut matches = cursor.matches(&query, root, bytes);
 
     while let Some(m) = matches.next() {
-        if let Some(f) =
-            process_first_arg_pattern(m, &caps, bytes, &aliases, content, line_offset)
+        if let Some(f) = process_first_arg_pattern(m, &caps, bytes, &aliases, content, line_offset)
         {
             findings.push(f);
         }
@@ -203,7 +202,8 @@ fn process_first_arg_pattern(
         point_to_position(func_cap.node.end_position()),
         line_offset,
     ));
-    let type_arg_info = extract_type_argument_info(m, caps.call_generic, caps.call_await_generic, content);
+    let type_arg_info =
+        extract_type_argument_info(m, caps.call_generic, caps.call_await_generic, content);
     let return_type = type_arg_info.as_ref().map(|i| i.type_text.clone());
     let type_arg_range = type_arg_info.map(|i| adjust_range(i.type_arg_range, line_offset));
 

--- a/lsp-server/src/tree_parser/mod.rs
+++ b/lsp-server/src/tree_parser/mod.rs
@@ -57,9 +57,9 @@ pub fn parse(path: &Path, content: &str) -> ParseResult<FileIndex> {
             parser.set_language(&ts_lang).map_err(|e| {
                 ParseError::LanguageError(format!("Failed to set Rust language: {e}"))
             })?;
-            let tree = parser.parse(content, None).ok_or_else(|| {
-                ParseError::SyntaxError("Failed to parse Rust file".to_string())
-            })?;
+            let tree = parser
+                .parse(content, None)
+                .ok_or_else(|| ParseError::SyntaxError("Failed to parse Rust file".to_string()))?;
             extract_rust_findings(tree.root_node(), content, &ts_lang)?
         }
         Some(lang_val @ (LangType::TypeScript | LangType::JavaScript | LangType::Angular)) => {
@@ -120,8 +120,7 @@ pub fn parse_rust_full(content: &str, path: &Path) -> ParseResult<RustFileIndex>
         rust_type_extractor::extract_command_schemas_from_tree(root, content, path);
 
     // 3. Extract event schemas
-    let event_schemas =
-        rust_type_extractor::extract_event_schemas_from_tree(root, content, path);
+    let event_schemas = rust_type_extractor::extract_event_schemas_from_tree(root, content, path);
 
     Ok(RustFileIndex {
         file_index: FileIndex {

--- a/lsp-server/tests/bindings_reader_tests.rs
+++ b/lsp-server/tests/bindings_reader_tests.rs
@@ -5,7 +5,7 @@ mod common_paths;
 
 use common_fixtures::load_fixture;
 use common_paths::test_path;
-use lsp_server::bindings_reader::{parse_specta_bindings, parse_ts_rs_types, parse_typegen_types};
+use lsp_server::bindings_reader::{parse_specta_bindings, parse_typescript_types};
 use lsp_server::file_processor::process_file_content;
 use lsp_server::indexer::{DiscoveredGenerator, GeneratorKind, ProjectIndex};
 use lsp_server::utils::camel_to_snake;
@@ -102,7 +102,7 @@ fn test_parse_specta_multi_params() {
 #[test]
 fn test_parse_ts_rs_type_aliases() {
     let content = load_fixture("bindings/ts_rs_types.ts");
-    let aliases = parse_ts_rs_types(&content);
+    let aliases = parse_typescript_types(&content);
 
     assert!(
         aliases.contains_key("UserProfile"),
@@ -122,7 +122,7 @@ fn test_parse_ts_rs_type_aliases() {
 #[test]
 fn test_parse_typegen_export_type_lines() {
     let content = load_fixture("bindings/typegen_bindings.ts");
-    let aliases = parse_typegen_types(&content);
+    let aliases = parse_typescript_types(&content);
 
     assert!(aliases.contains_key("SimpleUser"), "Should find SimpleUser");
     assert!(
@@ -135,7 +135,7 @@ fn test_parse_typegen_export_type_lines() {
 #[test]
 fn test_parse_typegen_export_interface_blocks() {
     let content = load_fixture("bindings/typegen_bindings.ts");
-    let aliases = parse_typegen_types(&content);
+    let aliases = parse_typescript_types(&content);
 
     // export interface UserProfile { id: number; name: string; ... }
     assert!(
@@ -160,7 +160,7 @@ fn test_parse_typegen_export_interface_blocks() {
 #[test]
 fn test_parse_typegen_interface_skips_index_signatures() {
     let content = load_fixture("bindings/typegen_bindings.ts");
-    let aliases = parse_typegen_types(&content);
+    let aliases = parse_typescript_types(&content);
 
     // GreetParams has `[key: string]: unknown` which should be skipped
     assert!(
@@ -192,7 +192,7 @@ export interface SimpleModel {
 }
 "#;
 
-    let aliases = parse_typegen_types(content);
+    let aliases = parse_typescript_types(content);
     assert!(aliases.contains_key("SimpleModel"));
     let def = &aliases["SimpleModel"];
     assert!(def.contains("id: number"));

--- a/lsp-server/tests/helpers.rs
+++ b/lsp-server/tests/helpers.rs
@@ -132,18 +132,16 @@ pub fn parse_fixture(input: &str) -> FixtureData {
                     index.add_schema(schema);
                 }
 
-                let evt_schemas =
-                    lsp_server::bindings_reader::parse_specta_events(&content, &path);
+                let evt_schemas = lsp_server::bindings_reader::parse_specta_events(&content, &path);
                 for schema in evt_schemas {
                     index.add_event_schema(schema);
                 }
             }
 
-            // Parse type aliases (ts-rs and typegen)
+            // Parse type aliases (Specta, ts-rs, and typegen)
             let aliases = match gen_kind {
-                GeneratorKind::TsRs => lsp_server::bindings_reader::parse_ts_rs_types(&content),
-                GeneratorKind::Typegen => {
-                    lsp_server::bindings_reader::parse_typegen_types(&content)
+                GeneratorKind::Specta | GeneratorKind::TsRs | GeneratorKind::Typegen => {
+                    lsp_server::bindings_reader::parse_typescript_types(&content)
                 }
                 _ => std::collections::HashMap::new(),
             };


### PR DESCRIPTION
   - Map both 'export' and 'export_to' methods to GeneratorKind::Specta
   - Ensure Specta generator kind parses type aliases for complete indexing
   - Correct swapped comments in constants.rs regarding Specta crates