### PR TITLE
ci: add manual approval gates for release and pre-release workflows

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -16,6 +16,7 @@ jobs:
     name: Publish Pre-Release
     runs-on: ubuntu-latest
     needs: build
+    environment: pre-release
 
     steps:
       - name: Checkout repository
@@ -90,3 +91,4 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       prerelease: true
+      environment: pre-release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
     name: Publish VS Code Extension
     runs-on: ubuntu-latest
     needs: build
+    environment: release
 
     steps:
       - name: Checkout repository
@@ -87,3 +88,4 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       prerelease: false
+      environment: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,15 @@ on:
       prerelease:
         required: true
         type: boolean
+      environment:
+        required: true
+        type: string
 
 jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Add `environment: release` to publish jobs and GitHub Release creation so that deployments require explicit reviewer approval before proceeding.