### PR TITLE
feat(parser): add SolidJS support via TypeScriptJsx/JavaScriptJsx lan…

### DIFF
--- a/lsp-server/src/parser/lang_config.rs
+++ b/lsp-server/src/parser/lang_config.rs
@@ -10,7 +10,9 @@ pub(crate) const JS_QUERY: &str = include_str!("../queries/javascript.scm");
 pub enum LangType {
     Rust,
     TypeScript,
+    TypeScriptJsx,
     JavaScript,
+    JavaScriptJsx,
     Vue,
     Svelte,
     Angular,
@@ -22,8 +24,10 @@ impl LangType {
     pub fn from_extension(ext: &str) -> Option<Self> {
         match ext {
             "rs" => Some(Self::Rust),
-            "ts" | "tsx" => Some(Self::TypeScript),
-            "js" | "jsx" => Some(Self::JavaScript),
+            "ts" => Some(Self::TypeScript),
+            "tsx" => Some(Self::TypeScriptJsx),
+            "js" => Some(Self::JavaScript),
+            "jsx" => Some(Self::JavaScriptJsx),
             "vue" => Some(Self::Vue),
             "svelte" => Some(Self::Svelte),
             _ => None,
@@ -35,8 +39,12 @@ impl LangType {
 pub(crate) fn get_query_source(lang: LangType) -> &'static str {
     match lang {
         LangType::Rust => RUST_QUERY,
-        LangType::TypeScript | LangType::Vue | LangType::Svelte | LangType::Angular => TS_QUERY,
-        LangType::JavaScript => JS_QUERY,
+        LangType::TypeScript
+        | LangType::TypeScriptJsx
+        | LangType::Vue
+        | LangType::Svelte
+        | LangType::Angular => TS_QUERY,
+        LangType::JavaScript | LangType::JavaScriptJsx => JS_QUERY,
     }
 }
 

--- a/lsp-server/src/parser/mod.rs
+++ b/lsp-server/src/parser/mod.rs
@@ -55,9 +55,13 @@ pub fn parse(
                 .ok_or_else(|| ParseError::SyntaxError("Failed to parse Rust file".to_string()))?;
             extract_rust_findings(tree.root_node(), content, &ts_lang, global_constants)?
         }
-        Some(lang_val @ (LangType::TypeScript | LangType::JavaScript | LangType::Angular)) => {
-            parse_frontend(content, lang_val, 0, global_constants)?
-        }
+        Some(
+            lang_val @ (LangType::TypeScript
+            | LangType::TypeScriptJsx
+            | LangType::JavaScript
+            | LangType::JavaScriptJsx
+            | LangType::Angular),
+        ) => parse_frontend(content, lang_val, 0, global_constants)?,
         Some(LangType::Vue | LangType::Svelte) => {
             let blocks = extract_script_blocks(content);
             let mut all_findings = Vec::new();

--- a/lsp-server/src/parser/typescript/frontend.rs
+++ b/lsp-server/src/parser/typescript/frontend.rs
@@ -112,7 +112,8 @@ pub fn parse_frontend(
     global_constants: &HashMap<String, String>,
 ) -> ParseResult<Vec<Finding>> {
     let ts_lang: Language = match lang {
-        LangType::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+        LangType::JavaScript | LangType::JavaScriptJsx => tree_sitter_javascript::LANGUAGE.into(),
+        LangType::TypeScriptJsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
         _ => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
     };
 
@@ -137,7 +138,7 @@ pub fn parse_frontend(
     let aliases = collect_aliases(&query, root, bytes, &caps);
 
     // Extract constants from this file and merge global constants as fallback
-    let is_js = matches!(lang, LangType::JavaScript);
+    let is_js = matches!(lang, LangType::JavaScript | LangType::JavaScriptJsx);
     let mut constants = crate::utils::extract_js_constants(root, content, is_js);
     for (k, v) in global_constants {
         constants.entry(k.clone()).or_insert_with(|| v.clone());

--- a/lsp-server/tests/parse_tests.rs
+++ b/lsp-server/tests/parse_tests.rs
@@ -761,3 +761,82 @@ fn parse_rust_exact_demo_specta_librs() {
         findings.iter().map(|f| &f.key).collect::<Vec<_>>()
     );
 }
+
+// ===========================================================================
+// SolidJS (.tsx with JSX)
+// ===========================================================================
+
+#[test]
+fn parse_solidjs_invoke_in_jsx() {
+    helpers::check_parse(
+        r#"
+//- /App.tsx
+import { createSignal, onMount } from "solid-js";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, emit } from "@tauri-apps/api/event";
+
+function App() {
+  const [msg, setMsg] = createSignal("");
+
+  onMount(async () => {
+    const unlisten = await listen("backend-event", (e) => {
+      console.log(e.payload);
+    });
+  });
+
+  const greet = async () => {
+    const result = await invoke<string>("greet", { name: "World" });
+    setMsg(result);
+  };
+
+  const sendEvent = async () => {
+    await emit("frontend-ping", { from: "solid" });
+  };
+
+  return (
+    <div>
+      <button onClick={greet}>Greet</button>
+      <button onClick={sendEvent}>Ping</button>
+      <p>{msg()}</p>
+    </div>
+  );
+}
+
+export default App;
+"#,
+        expect![[r#"
+            /App.tsx:
+              Event Listen "backend-event" 8:35..8:48
+              Command Call "greet" 14:41..14:46 return_type=string
+              Event Emit "frontend-ping" 19:16..19:29"#]],
+    );
+}
+
+#[test]
+fn parse_solidjs_jsx_does_not_break_parsing() {
+    // Verifies that JSX syntax in .tsx files does not cause tree-sitter errors
+    // and that invoke calls inside JSX event handlers are still found.
+    helpers::check_parse(
+        r#"
+//- /Counter.tsx
+import { createSignal } from "solid-js";
+import { invoke } from "@tauri-apps/api/core";
+
+function Counter() {
+  const [count, setCount] = createSignal(0);
+
+  return (
+    <div>
+      <button onClick={() => invoke("increment", { value: count() })}>+</button>
+      <span>{count()}</span>
+    </div>
+  );
+}
+
+export default Counter;
+"#,
+        expect![[r#"
+            /Counter.tsx:
+              Command Call "increment" 8:37..8:46"#]],
+    );
+}


### PR DESCRIPTION
…g variants

  Use LANGUAGE_TSX for .tsx files so tree-sitter correctly handles JSX syntax.
  Add LANGUAGE_JSX variant for .jsx. Both variants still use the TypeScript
  query, only the grammar changes. Includes two parse tests for SolidJS JSX.

  Closed #67