### PR TITLE
fix(config): align Tauri config detection with official docs

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -19,14 +19,11 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:tauri.conf.json",
-    "onLanguage:rust",
-    "onLanguage:typescript",
-    "onLanguage:typescriptreact",
-    "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onLanguage:vue",
-    "onLanguage:svelte"
+    "workspaceContains:**/tauri.conf.json",
+    "workspaceContains:**/tauri.conf.json5",
+    "workspaceContains:**/Tauri.toml",
+    "workspaceContains:**/tauri.*.conf.json",
+    "workspaceContains:**/Tauri.*.toml"
   ],
   "main": "./out/src/extension.js",
   "icon": "images/icon.png",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -29,8 +29,74 @@ const getServerCommand = (context: ExtensionContext): string => {
   return context.asAbsolutePath(path.join('bin', binaryName));
 };
 
-const activate = (context: ExtensionContext) => {
+// Canonical list of Tauri configuration file names used to detect a Tauri
+// workspace, aligned with the documented config file formats:
+// https://v2.tauri.app/reference/config/ — base `tauri.conf.json`,
+// `tauri.conf.json5`, `Tauri.toml`, plus the `tauri.<platform>.conf.json` and
+// `Tauri.<platform>.toml` overrides (no platform-specific JSON5 exists).
+//
+// The same set is maintained by hand in two other places that must be updated
+// together whenever this list changes:
+//   - `activationEvents` in package.json (as `workspaceContains:**/<name>` entries)
+//   - `TAURI_CONFIG_FILES` in lsp-server/src/discovery/scanner.rs
+const TAURI_CONFIG_FILES = [
+  'tauri.conf.json',
+  'tauri.conf.json5',
+  'Tauri.toml',
+  'tauri.*.conf.json',
+  'Tauri.*.toml',
+] as const;
+
+const TAURI_CONFIG_GLOB = `**/{${TAURI_CONFIG_FILES.join(',')}}`;
+
+// Directories ignored during the search (mirrors EXCLUDED_DIRS in the Rust scanner),
+// so a config buried in target/, dist/, gen/, etc. does not spuriously start the server.
+const EXCLUDED_DIRS_GLOB =
+  '**/{node_modules,.git,.vscode,.github,docs,target,dist,build,gen}/**';
+
+// Returns true if the workspace contains at least one Tauri configuration file.
+// The server is not started otherwise, so no binary process is spawned.
+const hasTauriConfig = async (): Promise<boolean> => {
+  const matches = await vscode.workspace.findFiles(
+    TAURI_CONFIG_GLOB,
+    EXCLUDED_DIRS_GLOB,
+    1
+  );
+
+  return matches.length > 0;
+};
+
+const activate = async (context: ExtensionContext) => {
   console.log('[TARUS] Extension activating...');
+
+  // Register the restart command unconditionally so it exists even when the
+  // server was not started (e.g. a non-Tauri workspace). The handler reports a
+  // proper message instead of VS Code's "command not found".
+  context.subscriptions.push(
+    vscode.commands.registerCommand('tarus.restartServer', async () => {
+      if (!client) {
+        vscode.window.showErrorMessage('TARUS: server is not initialized.');
+        return;
+      }
+      try {
+        await client.stop();
+        await client.start();
+        vscode.window.showInformationMessage('TARUS: server restarted.');
+      } catch (error) {
+        vscode.window.showErrorMessage(
+          `TARUS: failed to restart server — ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    })
+  );
+
+  // Do not spawn the LSP server binary unless this is a Tauri project.
+  if (!(await hasTauriConfig())) {
+    console.log('[TARUS] No Tauri config found — server not started.');
+
+    return;
+  }
+
   // This path specifies where the binary will be located AFTER compilation.
   // We assume you'll copy the binary to the 'bin' folder within the client.
   const serverCommand = getServerCommand(context);
@@ -67,7 +133,7 @@ const activate = (context: ExtensionContext) => {
 
   // Start the client with error handling
   try {
-    client.start();
+    await client.start();
   } catch (error) {
     const errorMessage = `Failed to start TARUS LSP Server: ${error instanceof Error ? error.message : String(error)}`;
 
@@ -85,24 +151,6 @@ const activate = (context: ExtensionContext) => {
       console.error('[TARUS] LSP Server stopped unexpectedly');
     }
   });
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('tarus.restartServer', async () => {
-      if (!client) {
-        vscode.window.showErrorMessage('TARUS: server is not initialized.');
-        return;
-      }
-      try {
-        await client.stop();
-        await client.start();
-        vscode.window.showInformationMessage('TARUS: server restarted.');
-      } catch (error) {
-        vscode.window.showErrorMessage(
-          `TARUS: failed to restart server — ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-    })
-  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/lsp-server/src/discovery/scanner.rs
+++ b/lsp-server/src/discovery/scanner.rs
@@ -47,7 +47,17 @@ fn should_skip(entry: &DirEntry) -> bool {
     is_ignored_entry_name(name, is_dir)
 }
 
-/// List of valid Tauri configuration file names (in lowercase)
+/// List of valid Tauri configuration file names (in lowercase).
+///
+/// Kept aligned with the documented Tauri config file formats:
+/// <https://v2.tauri.app/reference/config/> — base `tauri.conf.json`,
+/// `tauri.conf.json5`, `Tauri.toml`, plus the `tauri.<platform>.conf.json` and
+/// `Tauri.<platform>.toml` overrides (no platform-specific JSON5 exists).
+///
+/// The same set is maintained by hand on the extension side and must be updated
+/// together whenever this list changes:
+///   - `TAURI_CONFIG_FILES` / `TAURI_CONFIG_GLOB` in extension/src/extension.ts
+///   - `activationEvents` in extension/package.json
 const TAURI_CONFIG_FILES: &[&str] = &[
     "tauri.conf.json",
     "tauri.conf.json5",
@@ -65,6 +75,19 @@ const TAURI_CONFIG_FILES: &[&str] = &[
 ];
 
 /// Helper: Check if a path points to a Tauri configuration file
+///
+/// This uses a case-insensitive, explicit filename list, so it can disagree with
+/// the extension's case-sensitive wildcard globs in two opposite directions —
+/// both benign:
+/// - Looser on case (`TAURI.CONF.JSON` matches here but not the glob): harmless,
+///   because the server only runs after the extension's glob already matched, so
+///   such names never reach this function.
+/// - Stricter on the middle segment: the extension's `tauri.*.conf.json` glob
+///   also matches non-platform names like `tauri.staging.conf.json`, which this
+///   list rejects. That is intentional — a standalone non-platform config is not
+///   a real Tauri project, so reporting "not Tauri" (empty capabilities) is the
+///   correct outcome; the extension merely over-activates and spawns an idle
+///   server in that rare case.
 fn is_tauri_config_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
@@ -232,5 +255,13 @@ mod tests {
         assert!(!is_tauri_config_path(Path::new("tauri.json"))); // Missing .conf or .toml
         assert!(!is_tauri_config_path(Path::new("Tauri.txt")));
         assert!(!is_tauri_config_path(Path::new("package.json")));
+
+        // Platform-specific JSON5 is not a documented Tauri format — only base
+        // JSON5 (`tauri.conf.json5`) and platform JSON/TOML overrides exist.
+        assert!(!is_tauri_config_path(Path::new("tauri.linux.conf.json5")));
+        assert!(!is_tauri_config_path(Path::new("tauri.windows.conf.json5")));
+        assert!(!is_tauri_config_path(Path::new("tauri.macos.conf.json5")));
+        assert!(!is_tauri_config_path(Path::new("tauri.android.conf.json5")));
+        assert!(!is_tauri_config_path(Path::new("tauri.ios.conf.json5")));
     }
 }


### PR DESCRIPTION
Activation is now driven entirely by Tauri config files: the extension only spawns the LSP server when a workspace contains one, and the config name lists on both sides are aligned with the documented formats (https://v2.tauri.app/reference/config/).

- drop undocumented platform-specific JSON5 variants (reverts 7559d7a)
- drop lowercase-only tauri.toml / tauri.*.toml (TOML is Tauri.toml)
- link the Tauri config docs in extension.ts and scanner.rs, and cross-reference the three hand-synced lists
- await client.start() so startup failures reach the error handler
- add negative tests locking platform-JSON5 out of is_tauri_config_path