### PR TITLE
fix(parser): skip indexing frontend files with syntax errors

### DIFF
--- a/lsp-server/src/parser/typescript/frontend.rs
+++ b/lsp-server/src/parser/typescript/frontend.rs
@@ -126,6 +126,19 @@ pub fn parse_frontend(
         .parse(content, None)
         .ok_or_else(|| ParseError::SyntaxError(format!("Failed to parse {lang:?} file")))?;
 
+    // tree-sitter is error-tolerant: a file that is broken mid-edit still parses
+    // into a tree with ERROR/MISSING nodes rather than returning None. Indexing
+    // such a tree yields partial findings — e.g. a half-typed `listen<...>()` lands
+    // in an ERROR node and is dropped while a valid `emit()` for the same event is
+    // still captured, producing a spurious "emitted but no listeners" diagnostic.
+    // Treat any syntax error as a parse failure so the pipeline keeps the file's
+    // last valid index (and suppresses diagnostics) until it parses cleanly again.
+    if tree.root_node().has_error() {
+        return Err(ParseError::SyntaxError(format!(
+            "{lang:?} file has syntax errors; keeping last valid index"
+        )));
+    }
+
     let query_src = get_query_source(lang);
     let query = Query::new(&ts_lang, query_src)
         .map_err(|e| ParseError::QueryError(format!("Failed to create {lang:?} query: {e}")))?;

--- a/lsp-server/tests/diagnostics_tests.rs
+++ b/lsp-server/tests/diagnostics_tests.rs
@@ -64,6 +64,28 @@ emit("$0my-event");
 }
 
 #[test]
+fn diag_no_false_positive_when_file_has_syntax_errors() {
+    // A file broken mid-edit (here: an unterminated string in the listener) parses
+    // into a tree with ERROR nodes. Indexing it would drop the half-typed `listen`
+    // while still capturing the valid `emit` below, yielding a spurious
+    // "emitted but no listeners" warning. The parser must reject such trees so the
+    // pipeline keeps the last valid index and suppresses diagnostics for the file.
+    helpers::check_diagnostics(
+        r#"
+//- /events.ts
+import { emit, listen } from "@tauri-apps/api/event";
+const setup = async () => {
+  await listen("my-event, (e) => {});
+};
+const emitIt = () => {
+  emit("$0my-event");
+};
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
 fn diag_event_listened_but_no_emitters() {
     helpers::check_diagnostics(
         r#"


### PR DESCRIPTION
tree-sitter is error-tolerant, so a file broken mid-edit still parses into a tree with ERROR/MISSING nodes instead of returning None. Indexing such a tree produces partial findings: a half-typed listen<...>() lands in an ERROR node and is dropped while a valid emit() for the same event is still captured, yielding a spurious "emitted but no listeners" diagnostic.

Reject trees containing errors from parse_frontend so the pipeline keeps the file last valid index and suppresses diagnostics until it parses cleanly again.