### PR TITLE
 fix(diagnostics): scope-aware name resolution and open-world guard

### DIFF
--- a/lsp-server/src/capabilities/diagnostics.rs
+++ b/lsp-server/src/capabilities/diagnostics.rs
@@ -8,7 +8,9 @@
 //!    tauri-typegen) has been indexed. Uses `CommandSchema` sourced from those generators;
 //!    `GeneratorKind::RustSource` schemas are intentionally excluded from type checking.
 
-use crate::indexer::{DiagnosticInfo, GeneratorKind, IndexKey, LocationInfo, ProjectIndex};
+use crate::indexer::{
+    DiagnosticInfo, DynamicUsages, GeneratorKind, IndexKey, LocationInfo, ProjectIndex,
+};
 use crate::syntax::Behavior;
 use serde_json::json;
 use std::path::PathBuf;
@@ -100,6 +102,7 @@ pub fn compute_file_diagnostics(path: &PathBuf, project_index: &ProjectIndex) ->
     };
 
     let has_bindings = project_index.has_bindings_files();
+    let dynamic = project_index.dynamic_usages();
     let mut diagnostics = Vec::new();
 
     for key in &keys {
@@ -123,6 +126,7 @@ pub fn compute_file_diagnostics(path: &PathBuf, project_index: &ProjectIndex) ->
                 &info,
                 first_call,
                 first_emit,
+                dynamic,
                 &mut diagnostics,
             );
 
@@ -141,18 +145,24 @@ fn compute_structural_diagnostics(
     info: &DiagnosticInfo,
     first_call: Option<tower_lsp_server::lsp_types::Range>,
     first_emit: Option<tower_lsp_server::lsp_types::Range>,
+    dynamic: DynamicUsages,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let msg = match loc.behavior {
         Behavior::Definition => {
             let (entity_label, usage_label, is_unused) = match key.entity {
-                crate::syntax::EntityType::Command => {
-                    ("Command", "invoked in frontend", !info.has_calls())
-                }
+                crate::syntax::EntityType::Command => (
+                    "Command",
+                    "invoked in frontend",
+                    !info.has_calls() && !dynamic.invokes,
+                ),
                 crate::syntax::EntityType::Event => (
                     "Event",
                     "emitted or listened for",
-                    !info.has_emitters() && !info.has_listeners(),
+                    !info.has_emitters()
+                        && !info.has_listeners()
+                        && !dynamic.emitters
+                        && !dynamic.listeners,
                 ),
             };
             if is_unused {
@@ -177,11 +187,11 @@ fn compute_structural_diagnostics(
                 None
             }
         }
-        Behavior::Listen if !info.has_emitters() => Some((
+        Behavior::Listen if !info.has_emitters() && !dynamic.emitters => Some((
             DiagnosticSeverity::WARNING,
             format!("Event '{}' is listened for but never emitted", key.name),
         )),
-        Behavior::Emit if !info.has_listeners() => {
+        Behavior::Emit if !info.has_listeners() && !dynamic.listeners => {
             if first_emit == Some(loc.range) {
                 Some((
                     DiagnosticSeverity::WARNING,

--- a/lsp-server/src/indexer/lens.rs
+++ b/lsp-server/src/indexer/lens.rs
@@ -48,14 +48,15 @@ impl ProjectIndex {
                             same_file_targets.push(target.clone());
                         }
                     } else if target.path.extension().and_then(|s| s.to_str()) == Some("rs") {
-                        rust_targets.push(target.clone());
+                        // A Rust file links only to its frontend counterparts;
+                        // Rust-to-Rust references are the language server's own
+                        // job, not ours.
+                        if !is_current_rust {
+                            rust_targets.push(target.clone());
+                        }
                     } else {
                         frontend_targets.push(target.clone());
                     }
-                }
-
-                if is_current_rust {
-                    rust_targets.clear();
                 }
 
                 // The limit caps how many links one lens row offers, so it is

--- a/lsp-server/src/indexer/lens.rs
+++ b/lsp-server/src/indexer/lens.rs
@@ -31,60 +31,71 @@ impl ProjectIndex {
             let current_file_locations: Vec<&LocationInfo> =
                 all_locations.iter().filter(|l| l.path == path).collect();
 
-            let targets: Vec<LocationInfo> = all_locations
-                .iter()
-                .filter(|l| l.path != path)
-                .cloned()
-                .collect();
-
-            if targets.is_empty() {
-                continue;
-            }
-
             let is_current_rust = path.extension().and_then(|s| s.to_str()) == Some("rs");
             let limit = self.reference_limit.load(Ordering::Relaxed);
 
-            let mut rust_targets = Vec::new();
-            let mut frontend_targets = Vec::new();
-
-            for t in &targets {
-                if t.path.extension().and_then(|s| s.to_str()) == Some("rs") {
-                    rust_targets.push(t.clone());
-                } else {
-                    frontend_targets.push(t.clone());
-                }
-            }
-
             for my_loc in current_file_locations {
-                if is_current_rust {
-                    push_file_lenses(
-                        &mut result,
-                        my_loc.range,
-                        frontend_targets.clone(),
-                        limit,
-                        "references",
-                    );
-                } else {
-                    push_file_lenses(
-                        &mut result,
-                        my_loc.range,
-                        rust_targets.clone(),
-                        limit,
-                        "rust refs",
-                    );
-                    push_file_lenses(
-                        &mut result,
-                        my_loc.range,
-                        frontend_targets.clone(),
-                        limit,
-                        "references",
-                    );
+                // Only the lens's own location is excluded, never its whole file:
+                // the other side of an event is just as hard to find a hundred lines
+                // down as it is in a neighbouring file.
+                let mut rust_targets = Vec::new();
+                let mut frontend_targets = Vec::new();
+                let mut same_file_targets = Vec::new();
+
+                for target in all_locations.iter() {
+                    if target.path == path {
+                        if target.range != my_loc.range {
+                            same_file_targets.push(target.clone());
+                        }
+                    } else if target.path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                        rust_targets.push(target.clone());
+                    } else {
+                        frontend_targets.push(target.clone());
+                    }
                 }
+
+                if !is_current_rust {
+                    push_file_lenses(&mut result, my_loc.range, rust_targets, limit, "rust refs");
+                }
+
+                push_file_lenses(
+                    &mut result,
+                    my_loc.range,
+                    frontend_targets,
+                    limit,
+                    "references",
+                );
+                push_same_file_lens(&mut result, my_loc.range, same_file_targets);
             }
         }
 
         result
     }
+}
+
+/// Lens for references living in the file being viewed.
+///
+/// Naming the file would be tautological here, so a single target shows the line
+/// to jump to and several are summarised by count.
+fn push_same_file_lens(
+    result: &mut Vec<(Range, String, Vec<LocationInfo>)>,
+    range: Range,
+    mut targets: Vec<LocationInfo>,
+) {
+    if targets.is_empty() {
+        return;
+    }
+
+    targets.sort_by_key(|t| (t.range.start.line, t.range.start.character));
+
+    let title = if targets.len() == 1 {
+        // Editors count lines from one.
+        format!("Go to line {}", targets[0].range.start.line + 1)
+    } else {
+        format!("{} in this file", targets.len())
+    };
+
+    result.push((range, title, targets));
 }
 
 fn push_file_lenses(

--- a/lsp-server/src/indexer/lens.rs
+++ b/lsp-server/src/indexer/lens.rs
@@ -54,18 +54,34 @@ impl ProjectIndex {
                     }
                 }
 
-                if !is_current_rust {
-                    push_file_lenses(&mut result, my_loc.range, rust_targets, limit, "rust refs");
+                if is_current_rust {
+                    rust_targets.clear();
                 }
+
+                // The limit caps how many links one lens row offers, so it is
+                // measured across every category at once. Counting each category
+                // on its own let a line show `limit` Rust links *and* `limit`
+                // frontend ones, which is what the setting exists to prevent.
+                let link_count = distinct_files(&rust_targets)
+                    + distinct_files(&frontend_targets)
+                    + same_file_targets.len();
+                let summarise = link_count > limit;
 
                 push_file_lenses(
                     &mut result,
                     my_loc.range,
-                    frontend_targets,
-                    limit,
-                    "references",
+                    rust_targets,
+                    summarise,
+                    "rust ref",
                 );
-                push_same_file_lens(&mut result, my_loc.range, same_file_targets);
+                push_file_lenses(
+                    &mut result,
+                    my_loc.range,
+                    frontend_targets,
+                    summarise,
+                    "reference",
+                );
+                push_same_file_lens(&mut result, my_loc.range, same_file_targets, summarise);
             }
         }
 
@@ -73,14 +89,34 @@ impl ProjectIndex {
     }
 }
 
+/// Number of distinct files a set of locations points at — one link is offered
+/// per file, not per location.
+fn distinct_files(targets: &[LocationInfo]) -> usize {
+    targets
+        .iter()
+        .map(|t| &t.path)
+        .collect::<std::collections::HashSet<_>>()
+        .len()
+}
+
+/// Pluralise a summary label against the count it is shown with.
+fn summary_title(count: usize, label: &str) -> String {
+    if count == 1 {
+        format!("{count} {label}")
+    } else {
+        format!("{count} {label}s")
+    }
+}
+
 /// Lens for references living in the file being viewed.
 ///
-/// Naming the file would be tautological here, so a single target shows the line
-/// to jump to and several are summarised by count.
+/// Naming the file would be tautological here, so each target is offered by line
+/// number instead.
 fn push_same_file_lens(
     result: &mut Vec<(Range, String, Vec<LocationInfo>)>,
     range: Range,
     mut targets: Vec<LocationInfo>,
+    summarise: bool,
 ) {
     if targets.is_empty() {
         return;
@@ -88,21 +124,25 @@ fn push_same_file_lens(
 
     targets.sort_by_key(|t| (t.range.start.line, t.range.start.character));
 
-    let title = if targets.len() == 1 {
-        // Editors count lines from one.
-        format!("Go to line {}", targets[0].range.start.line + 1)
-    } else {
-        format!("{} in this file", targets.len())
-    };
+    if summarise {
+        result.push((range, format!("{} in this file", targets.len()), targets));
 
-    result.push((range, title, targets));
+        return;
+    }
+
+    for target in targets {
+        // Editors count lines from one.
+        let title = format!("Go to line {}", target.range.start.line + 1);
+
+        result.push((range, title, vec![target]));
+    }
 }
 
 fn push_file_lenses(
     result: &mut Vec<(Range, String, Vec<LocationInfo>)>,
     range: Range,
     targets: Vec<LocationInfo>,
-    limit: usize,
+    summarise: bool,
     summary_label: &str,
 ) {
     if targets.is_empty() {
@@ -114,24 +154,24 @@ fn push_file_lenses(
         files_map.entry(t.path.clone()).or_default().push(t.clone());
     }
 
-    if files_map.len() <= limit {
-        let mut sorted_files: Vec<_> = files_map.into_iter().collect();
-        sorted_files.sort_by(|a, b| a.0.cmp(&b.0));
+    if summarise {
+        let title = summary_title(files_map.len(), summary_label);
 
-        for (fpath, locs) in sorted_files {
-            let fname = fpath
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string();
+        result.push((range, title, targets));
 
-            result.push((range, format!("Go to {fname}"), locs));
-        }
-    } else {
-        result.push((
-            range,
-            format!("{} {}", targets.len(), summary_label),
-            targets,
-        ));
+        return;
+    }
+
+    let mut sorted_files: Vec<_> = files_map.into_iter().collect();
+    sorted_files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (fpath, locs) in sorted_files {
+        let fname = fpath
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        result.push((range, format!("Go to {fname}"), locs));
     }
 }

--- a/lsp-server/src/indexer/mod.rs
+++ b/lsp-server/src/indexer/mod.rs
@@ -60,6 +60,12 @@ pub struct ProjectIndex {
     pub(crate) js_constants_paths: DashMap<PathBuf, Vec<String>>,
     // Files holding Tauri calls whose name could not be resolved to a literal
     pub(crate) dynamic_usages: DashMap<PathBuf, DynamicUsages>,
+    // Helpers that forward a parameter into a Tauri call: function_name -> every
+    // declaration seen under that name. Kept as a list so that two files declaring
+    // the same helper name are detected as ambiguous instead of overwriting.
+    pub(crate) forwarders: DashMap<String, Vec<(PathBuf, Forwarder)>>,
+    // Reverse index for stale removal: file_path -> declared forwarder names
+    pub(crate) forwarder_paths: DashMap<PathBuf, Vec<String>>,
 }
 
 impl Default for ProjectIndex {
@@ -84,6 +90,8 @@ impl Default for ProjectIndex {
             rust_constants_paths: DashMap::new(),
             js_constants_paths: DashMap::new(),
             dynamic_usages: DashMap::new(),
+            forwarders: DashMap::new(),
+            forwarder_paths: DashMap::new(),
         }
     }
 }
@@ -140,6 +148,8 @@ impl ProjectIndex {
                 .insert(path_ref.clone(), file_index.dynamic_usages);
         }
 
+        self.add_forwarders(path_ref.clone(), file_index.forwarders);
+
         for finding in file_index.findings {
             let key = IndexKey {
                 entity: finding.entity,
@@ -188,6 +198,7 @@ impl ProjectIndex {
         // constants and break cross-file constant resolution.
         self.parse_errors.remove(path);
         self.dynamic_usages.remove(path);
+        self.remove_forwarders_for_file(path);
     }
 
     /// Unresolved Tauri call sites across the whole workspace, folded into one value.
@@ -271,6 +282,57 @@ impl ProjectIndex {
             self.js_constants.insert(name, value);
         }
         self.js_constants_paths.insert(path, names);
+    }
+
+    /// Store the forwarding helpers declared in a file, replacing any previous set.
+    pub fn add_forwarders(&self, path: PathBuf, forwarders: Vec<Forwarder>) {
+        self.remove_forwarders_for_file(&path);
+        let names: Vec<String> = forwarders.iter().map(|f| f.function_name.clone()).collect();
+
+        for forwarder in forwarders {
+            self.forwarders
+                .entry(forwarder.function_name.clone())
+                .or_default()
+                .push((path.clone(), forwarder));
+        }
+
+        self.forwarder_paths.insert(path, names);
+    }
+
+    /// Remove all forwarding helpers associated with a file
+    pub fn remove_forwarders_for_file(&self, path: &Path) {
+        if let Some((_, names)) = self.forwarder_paths.remove(path) {
+            for name in names {
+                let now_empty = self.forwarders.get_mut(&name).is_some_and(|mut entry| {
+                    entry.retain(|(declared_in, _)| declared_in != path);
+
+                    entry.is_empty()
+                });
+
+                if now_empty {
+                    self.forwarders.remove(&name);
+                }
+            }
+        }
+    }
+
+    /// Forwarding helpers that can be resolved unambiguously, keyed by function name.
+    ///
+    /// A name declared by two files with *different* shapes is dropped: without
+    /// following imports there is no way to tell which declaration a call site
+    /// means, and guessing would attribute the event to the wrong helper.
+    #[must_use]
+    pub fn get_all_forwarders(&self) -> std::collections::HashMap<String, Forwarder> {
+        self.forwarders
+            .iter()
+            .filter_map(|entry| {
+                let (first, rest) = entry.value().split_first()?;
+
+                rest.iter()
+                    .all(|(_, other)| other == &first.1)
+                    .then(|| (entry.key().clone(), first.1.clone()))
+            })
+            .collect()
     }
 
     /// Remove all Rust constants associated with a file

--- a/lsp-server/src/indexer/mod.rs
+++ b/lsp-server/src/indexer/mod.rs
@@ -58,6 +58,8 @@ pub struct ProjectIndex {
     // Reverse index for stale removal: file_path -> list of constant names
     pub(crate) rust_constants_paths: DashMap<PathBuf, Vec<String>>,
     pub(crate) js_constants_paths: DashMap<PathBuf, Vec<String>>,
+    // Files holding Tauri calls whose name could not be resolved to a literal
+    pub(crate) dynamic_usages: DashMap<PathBuf, DynamicUsages>,
 }
 
 impl Default for ProjectIndex {
@@ -81,6 +83,7 @@ impl Default for ProjectIndex {
             js_constants: DashMap::new(),
             rust_constants_paths: DashMap::new(),
             js_constants_paths: DashMap::new(),
+            dynamic_usages: DashMap::new(),
         }
     }
 }
@@ -130,6 +133,13 @@ impl ProjectIndex {
         let mut keys_in_this_file = std::collections::HashSet::new();
         let path_ref = file_index.path;
 
+        if file_index.dynamic_usages.is_empty() {
+            self.dynamic_usages.remove(&path_ref);
+        } else {
+            self.dynamic_usages
+                .insert(path_ref.clone(), file_index.dynamic_usages);
+        }
+
         for finding in file_index.findings {
             let key = IndexKey {
                 entity: finding.entity,
@@ -177,6 +187,19 @@ impl ProjectIndex {
         // so removing constants in `remove_file` would discard the freshly re-extracted
         // constants and break cross-file constant resolution.
         self.parse_errors.remove(path);
+        self.dynamic_usages.remove(path);
+    }
+
+    /// Unresolved Tauri call sites across the whole workspace, folded into one value.
+    #[must_use]
+    pub fn dynamic_usages(&self) -> DynamicUsages {
+        let mut merged = DynamicUsages::default();
+
+        for entry in &self.dynamic_usages {
+            merged.merge(*entry.value());
+        }
+
+        merged
     }
 
     /// Store a parse error for a file

--- a/lsp-server/src/indexer/types.rs
+++ b/lsp-server/src/indexer/types.rs
@@ -137,11 +137,32 @@ impl DynamicUsages {
     }
 }
 
+/// A helper that passes one of its own parameters straight into a Tauri call, e.g.
+///
+/// ```ts
+/// const emitToOverlays = async (event: string, payload: unknown) =>
+///   emitTo("overlay", event, payload);
+/// ```
+///
+/// The event name never appears at the `emitTo`; it appears at each call of the
+/// helper. Recording the forwarder lets those call sites be indexed as real emit
+/// sites, so navigation, `CodeLens` and references reach the other side.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Forwarder {
+    /// Name the helper is called by.
+    pub function_name: String,
+    /// Which argument of the helper carries the command/event name.
+    pub param_index: usize,
+    pub entity: EntityType,
+    pub behavior: Behavior,
+}
+
 #[derive(Debug, Default)]
 pub struct FileIndex {
     pub path: PathBuf,
     pub findings: Vec<Finding>,
     pub dynamic_usages: DynamicUsages,
+    pub forwarders: Vec<Forwarder>,
 }
 
 /// Search Key (Hashmap Key)

--- a/lsp-server/src/indexer/types.rs
+++ b/lsp-server/src/indexer/types.rs
@@ -99,10 +99,49 @@ impl From<(&PathBuf, Finding)> for LocationInfo {
     }
 }
 
-#[derive(Debug)]
+/// Tauri call sites in a file whose command/event name could not be resolved to a
+/// string literal — e.g. `emit(eventName, payload)` where `eventName` is a parameter.
+///
+/// Such a call still uses *some* command or event, we just cannot tell which. Any
+/// diagnostic that reports an *absence* ("never emitted", "never invoked") assumes a
+/// closed world, so a single unresolved call site of the matching kind invalidates it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DynamicUsages {
+    pub invokes: bool,
+    pub emitters: bool,
+    pub listeners: bool,
+}
+
+impl DynamicUsages {
+    /// Record a dynamic usage for the given behavior. Definitions always carry a
+    /// literal name, so they can never be dynamic.
+    pub fn record(&mut self, behavior: Behavior) {
+        match behavior {
+            Behavior::Call | Behavior::SpectaCall => self.invokes = true,
+            Behavior::Emit => self.emitters = true,
+            Behavior::Listen => self.listeners = true,
+            Behavior::Definition => {}
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        !self.invokes && !self.emitters && !self.listeners
+    }
+
+    /// Fold another file's usages into this one.
+    pub fn merge(&mut self, other: Self) {
+        self.invokes |= other.invokes;
+        self.emitters |= other.emitters;
+        self.listeners |= other.listeners;
+    }
+}
+
+#[derive(Debug, Default)]
 pub struct FileIndex {
     pub path: PathBuf,
     pub findings: Vec<Finding>,
+    pub dynamic_usages: DynamicUsages,
 }
 
 /// Search Key (Hashmap Key)

--- a/lsp-server/src/parser/mod.rs
+++ b/lsp-server/src/parser/mod.rs
@@ -11,7 +11,7 @@ pub mod typescript;
 
 pub use lang_config::LangType;
 
-use crate::indexer::{CommandSchema, EventSchema, FileIndex};
+use crate::indexer::{CommandSchema, DynamicUsages, EventSchema, FileIndex};
 use crate::syntax::{ParseError, ParseResult};
 use lang_config::is_angular_file;
 use rust::commands::extract_rust_findings;
@@ -43,6 +43,8 @@ pub fn parse(
         LangType::from_extension(ext)
     };
 
+    let mut dynamic_usages = DynamicUsages::default();
+
     let findings = match lang {
         Some(LangType::Rust) => {
             let ts_lang: Language = tree_sitter_rust::LANGUAGE.into();
@@ -53,7 +55,11 @@ pub fn parse(
             let tree = parser
                 .parse(content, None)
                 .ok_or_else(|| ParseError::SyntaxError("Failed to parse Rust file".to_string()))?;
-            extract_rust_findings(tree.root_node(), content, &ts_lang, global_constants)?
+            let parsed =
+                extract_rust_findings(tree.root_node(), content, &ts_lang, global_constants)?;
+            dynamic_usages.merge(parsed.dynamic_usages);
+
+            parsed.findings
         }
         Some(
             lang_val @ (LangType::TypeScript
@@ -61,19 +67,25 @@ pub fn parse(
             | LangType::JavaScript
             | LangType::JavaScriptJsx
             | LangType::Angular),
-        ) => parse_frontend(content, lang_val, 0, global_constants)?,
+        ) => {
+            let parsed = parse_frontend(content, lang_val, 0, global_constants)?;
+            dynamic_usages.merge(parsed.dynamic_usages);
+
+            parsed.findings
+        }
         Some(LangType::Vue | LangType::Svelte) => {
             let blocks = extract_script_blocks(content);
             let mut all_findings = Vec::new();
 
             for (script_content, line_offset) in blocks {
-                let findings = parse_frontend(
+                let parsed = parse_frontend(
                     &script_content,
                     LangType::TypeScript,
                     line_offset,
                     global_constants,
                 )?;
-                all_findings.extend(findings);
+                dynamic_usages.merge(parsed.dynamic_usages);
+                all_findings.extend(parsed.findings);
             }
 
             all_findings
@@ -84,6 +96,7 @@ pub fn parse(
     Ok(FileIndex {
         path: path.to_path_buf(),
         findings,
+        dynamic_usages,
     })
 }
 
@@ -117,14 +130,15 @@ pub fn parse_rust_full(
 
     let root = tree.root_node();
 
-    let findings = extract_rust_findings(root, content, &ts_lang, global_constants)?;
+    let parsed = extract_rust_findings(root, content, &ts_lang, global_constants)?;
     let command_schemas = rust::types::extract_command_schemas_from_tree(root, content, path);
     let event_schemas = rust::types::extract_event_schemas_from_tree(root, content, path);
 
     Ok(RustFileIndex {
         file_index: FileIndex {
             path: path.to_path_buf(),
-            findings,
+            findings: parsed.findings,
+            dynamic_usages: parsed.dynamic_usages,
         },
         command_schemas,
         event_schemas,

--- a/lsp-server/src/parser/mod.rs
+++ b/lsp-server/src/parser/mod.rs
@@ -11,7 +11,7 @@ pub mod typescript;
 
 pub use lang_config::LangType;
 
-use crate::indexer::{CommandSchema, DynamicUsages, EventSchema, FileIndex};
+use crate::indexer::{CommandSchema, DynamicUsages, EventSchema, FileIndex, Forwarder};
 use crate::syntax::{ParseError, ParseResult};
 use lang_config::is_angular_file;
 use rust::commands::extract_rust_findings;
@@ -32,6 +32,7 @@ pub fn parse(
     path: &Path,
     content: &str,
     global_constants: &HashMap<String, String>,
+    known_forwarders: &HashMap<String, Forwarder>,
 ) -> ParseResult<FileIndex> {
     let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
 
@@ -44,6 +45,7 @@ pub fn parse(
     };
 
     let mut dynamic_usages = DynamicUsages::default();
+    let mut forwarders = Vec::new();
 
     let findings = match lang {
         Some(LangType::Rust) => {
@@ -68,8 +70,9 @@ pub fn parse(
             | LangType::JavaScriptJsx
             | LangType::Angular),
         ) => {
-            let parsed = parse_frontend(content, lang_val, 0, global_constants)?;
+            let parsed = parse_frontend(content, lang_val, 0, global_constants, known_forwarders)?;
             dynamic_usages.merge(parsed.dynamic_usages);
+            forwarders.extend(parsed.forwarders);
 
             parsed.findings
         }
@@ -83,8 +86,10 @@ pub fn parse(
                     LangType::TypeScript,
                     line_offset,
                     global_constants,
+                    known_forwarders,
                 )?;
                 dynamic_usages.merge(parsed.dynamic_usages);
+                forwarders.extend(parsed.forwarders);
                 all_findings.extend(parsed.findings);
             }
 
@@ -97,6 +102,7 @@ pub fn parse(
         path: path.to_path_buf(),
         findings,
         dynamic_usages,
+        forwarders,
     })
 }
 
@@ -139,6 +145,7 @@ pub fn parse_rust_full(
             path: path.to_path_buf(),
             findings: parsed.findings,
             dynamic_usages: parsed.dynamic_usages,
+            forwarders: Vec::new(),
         },
         command_schemas,
         event_schemas,

--- a/lsp-server/src/parser/rust/commands.rs
+++ b/lsp-server/src/parser/rust/commands.rs
@@ -1,6 +1,6 @@
 //! Rust source code parsing for Tauri commands and events
 
-use crate::indexer::Finding;
+use crate::indexer::{DynamicUsages, Finding};
 use crate::syntax::{Behavior, EntityType, ParseError, ParseResult};
 use crate::utils::{find_capture, point_to_position};
 use std::collections::HashMap;
@@ -27,6 +27,12 @@ static RUST_EVENT_PATTERNS: LazyLock<HashMap<&'static str, (EntityType, Behavior
         m
     });
 
+/// Result of parsing one Rust file.
+pub struct RustParse {
+    pub findings: Vec<Finding>,
+    pub dynamic_usages: DynamicUsages,
+}
+
 /// Extract findings from a pre-parsed Rust tree root node.
 ///
 /// # Errors
@@ -38,7 +44,7 @@ pub fn extract_rust_findings(
     content: &str,
     ts_lang: &Language,
     global_constants: &HashMap<String, String>,
-) -> ParseResult<Vec<Finding>> {
+) -> ParseResult<RustParse> {
     let query = Query::new(ts_lang, RUST_QUERY)
         .map_err(|e| ParseError::QueryError(format!("Failed to create Rust query: {e}")))?;
 
@@ -62,6 +68,7 @@ pub fn extract_rust_findings(
     }
 
     let mut findings = Vec::new();
+    let mut dynamic_usages = DynamicUsages::default();
     let mut matches = cursor.matches(&query, root, bytes);
 
     while let Some(m) = matches.next() {
@@ -77,14 +84,17 @@ pub fn extract_rust_findings(
             findings.push(f);
             continue;
         }
-        if let Some(f) =
-            process_event_call(m, method_name_idx, event_name_idx, bytes, &local_constants)
-        {
-            findings.push(f);
+        match process_event_call(m, method_name_idx, event_name_idx, bytes, &local_constants) {
+            EventCallOutcome::Found(f) => findings.push(f),
+            EventCallOutcome::Dynamic(behavior) => dynamic_usages.record(behavior),
+            EventCallOutcome::NoMatch => {}
         }
     }
 
-    Ok(findings)
+    Ok(RustParse {
+        findings,
+        dynamic_usages,
+    })
 }
 
 fn process_specta_emit(
@@ -162,83 +172,81 @@ fn process_fn(
     ))
 }
 
+/// What a query match yielded for a Rust `emit`/`listen`-style call.
+enum EventCallOutcome {
+    /// The call names a known event.
+    Found(Finding),
+    /// The call is an event call whose name could not be resolved to a literal.
+    Dynamic(Behavior),
+    /// The match is not an event call at all.
+    NoMatch,
+}
+
 fn process_event_call(
     m: &tree_sitter::QueryMatch<'_, '_>,
     method_name_idx: Option<u32>,
     event_name_idx: Option<u32>,
     bytes: &[u8],
     constants: &std::collections::HashMap<String, String>,
-) -> Option<Finding> {
-    let method_cap = find_capture(m, method_name_idx)?;
-    let event_cap = find_capture(m, event_name_idx)?;
+) -> EventCallOutcome {
+    let (Some(method_cap), Some(event_cap)) = (
+        find_capture(m, method_name_idx),
+        find_capture(m, event_name_idx),
+    ) else {
+        return EventCallOutcome::NoMatch;
+    };
 
     let method_name = method_cap.node.utf8_text(bytes).unwrap_or_default();
-    let raw_event_name = event_cap.node.utf8_text(bytes).unwrap_or_default();
-
-    let mut resolved_name = raw_event_name.to_string();
-    if event_cap.node.kind() == "string_literal" {
-        if let Some(content_node) = event_cap.node.child_by_field_name("content") {
-            resolved_name = content_node
-                .utf8_text(bytes)
-                .unwrap_or_default()
-                .to_string();
-        } else if let Some(content_node) = event_cap.node.named_child(0) {
-            resolved_name = content_node
-                .utf8_text(bytes)
-                .unwrap_or_default()
-                .to_string();
-        } else if resolved_name.starts_with('"')
-            && resolved_name.ends_with('"')
-            && resolved_name.len() >= 2
-        {
-            resolved_name = resolved_name[1..resolved_name.len() - 1].to_string();
-        }
-    } else {
-        let mut resolved = false;
-        if let Some(resolved_val) = constants.get(&resolved_name) {
-            resolved_name.clone_from(resolved_val);
-            resolved = true;
-        } else {
-            let lookup_key = if resolved_name.contains("::") {
-                resolved_name
-                    .split("::")
-                    .last()
-                    .unwrap_or(resolved_name.as_str())
-            } else {
-                resolved_name.as_str()
-            };
-            if let Some(resolved_val) = constants.get(lookup_key) {
-                resolved_name.clone_from(resolved_val);
-                resolved = true;
-            }
-        }
-        if !resolved {
-            resolved_name.clear();
-        }
-    }
-
-    if resolved_name.is_empty() {
-        return None;
-    }
-
-    let mut range = Range {
-        start: point_to_position(event_cap.node.start_position()),
-        end: point_to_position(event_cap.node.end_position()),
+    let Some((entity, behavior)) = RUST_EVENT_PATTERNS.get(method_name) else {
+        return EventCallOutcome::NoMatch;
     };
-    if event_cap.node.kind() == "string_literal" {
-        if let Some(content_node) = event_cap.node.child_by_field_name("content") {
-            range = Range {
-                start: point_to_position(content_node.start_position()),
-                end: point_to_position(content_node.end_position()),
-            };
-        } else if let Some(content_node) = event_cap.node.named_child(0) {
-            range = Range {
-                start: point_to_position(content_node.start_position()),
-                end: point_to_position(content_node.end_position()),
-            };
+
+    let raw_event_name = event_cap.node.utf8_text(bytes).unwrap_or_default();
+    let is_literal = event_cap.node.kind() == "string_literal";
+
+    let literal_content = is_literal
+        .then(|| {
+            event_cap
+                .node
+                .child_by_field_name("content")
+                .or_else(|| event_cap.node.named_child(0))
+        })
+        .flatten();
+
+    let resolved_name = if is_literal {
+        literal_content.map_or_else(
+            || {
+                raw_event_name
+                    .strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .unwrap_or(raw_event_name)
+                    .to_string()
+            },
+            |node| node.utf8_text(bytes).unwrap_or_default().to_string(),
+        )
+    } else {
+        let lookup_key = raw_event_name.rsplit("::").next().unwrap_or(raw_event_name);
+
+        match constants
+            .get(raw_event_name)
+            .or_else(|| constants.get(lookup_key))
+        {
+            Some(value) => value.clone(),
+            None => return EventCallOutcome::Dynamic(*behavior),
         }
+    };
+
+    // `app.emit("", ..)` names nothing, but it is not unknown either: an empty
+    // literal must not weaken diagnostics the way a dynamic name does.
+    if resolved_name.is_empty() {
+        return EventCallOutcome::NoMatch;
     }
 
-    let (entity, behavior) = RUST_EVENT_PATTERNS.get(method_name)?;
-    Some(Finding::new(resolved_name, *entity, *behavior, range))
+    let name_node = literal_content.unwrap_or(event_cap.node);
+    let range = Range {
+        start: point_to_position(name_node.start_position()),
+        end: point_to_position(name_node.end_position()),
+    };
+
+    EventCallOutcome::Found(Finding::new(resolved_name, *entity, *behavior, range))
 }

--- a/lsp-server/src/parser/typescript/frontend.rs
+++ b/lsp-server/src/parser/typescript/frontend.rs
@@ -1,6 +1,6 @@
 //! TypeScript/JavaScript/Vue/Svelte/Angular parsing for Tauri invoke/emit/listen calls
 
-use crate::indexer::Finding;
+use crate::indexer::{DynamicUsages, Finding};
 use crate::syntax::{Behavior, EntityType, ParseError, ParseResult};
 use crate::utils::{find_capture, point_to_position};
 use std::collections::HashMap;
@@ -62,6 +62,62 @@ static ALL_FRONTEND_PATTERNS: LazyLock<Vec<FunctionPatternWithPos>> = LazyLock::
     ]
 });
 
+/// Result of parsing one frontend file.
+pub struct FrontendParse {
+    pub findings: Vec<Finding>,
+    pub dynamic_usages: DynamicUsages,
+}
+
+/// Everything needed to turn a command/event name argument into a literal.
+struct Scope<'a> {
+    /// String constants declared in the file being parsed.
+    local_constants: HashMap<String, String>,
+    /// String constants declared anywhere else in the workspace.
+    global_constants: &'a HashMap<String, String>,
+    /// Identifiers the file binds itself; they shadow `global_constants`.
+    bound_names: std::collections::HashSet<String>,
+}
+
+impl Scope<'_> {
+    /// Resolve an identifier or member expression to the string it stands for.
+    ///
+    /// Returns `None` when the name cannot be proven — either it is bound locally
+    /// to something that is not a string literal, or no constant declares it. A
+    /// workspace-wide constant is never applied to a locally bound name: doing so
+    /// invents a name out of an unrelated file and reports diagnostics against it.
+    fn resolve(&self, raw: &str) -> Option<String> {
+        let base = raw.split('.').next().unwrap_or(raw);
+        let last = raw.split('.').next_back().unwrap_or(raw);
+
+        if let Some(value) = self
+            .local_constants
+            .get(raw)
+            .or_else(|| self.local_constants.get(last))
+        {
+            return Some(value.clone());
+        }
+
+        if self.bound_names.contains(base) {
+            return None;
+        }
+
+        self.global_constants
+            .get(raw)
+            .or_else(|| self.global_constants.get(last))
+            .cloned()
+    }
+}
+
+/// What a query match yielded for one of the call patterns.
+enum PatternOutcome {
+    /// The match is a Tauri call with a known command/event name.
+    Found(Finding),
+    /// The match is a Tauri call whose name could not be resolved to a literal.
+    Dynamic(Behavior),
+    /// The match is not a Tauri call at all.
+    NoMatch,
+}
+
 /// Capture indices extracted from the query, grouped for readability
 struct FrontendCaptures {
     func_name: Option<u32>,
@@ -110,7 +166,7 @@ pub fn parse_frontend(
     lang: LangType,
     line_offset: usize,
     global_constants: &HashMap<String, String>,
-) -> ParseResult<Vec<Finding>> {
+) -> ParseResult<FrontendParse> {
     let ts_lang: Language = match lang {
         LangType::JavaScript | LangType::JavaScriptJsx => tree_sitter_javascript::LANGUAGE.into(),
         LangType::TypeScriptJsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
@@ -150,28 +206,31 @@ pub fn parse_frontend(
     // First pass: collect import aliases
     let aliases = collect_aliases(&query, root, bytes, &caps);
 
-    // Extract constants from this file and merge global constants as fallback
+    // Local constants win over workspace-wide ones, and locally bound identifiers
+    // (parameters, destructured variables) win over both — see `Scope`.
     let is_js = matches!(lang, LangType::JavaScript | LangType::JavaScriptJsx);
-    let mut constants = crate::utils::extract_js_constants(root, content, is_js);
-    for (k, v) in global_constants {
-        constants.entry(k.clone()).or_insert_with(|| v.clone());
-    }
+    let scope = Scope {
+        local_constants: crate::utils::extract_js_constants(root, content, is_js),
+        global_constants,
+        bound_names: crate::utils::collect_bound_names(root, content),
+    };
 
     // Second pass: collect function calls
     let mut findings = Vec::new();
+    let mut dynamic_usages = DynamicUsages::default();
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(&query, root, bytes);
 
     while let Some(m) = matches.next() {
-        if let Some(f) =
-            process_first_arg_pattern(m, &caps, bytes, &aliases, &constants, content, line_offset)
-        {
-            findings.push(f);
+        match process_first_arg_pattern(m, &caps, bytes, &aliases, &scope, content, line_offset) {
+            PatternOutcome::Found(f) => findings.push(f),
+            PatternOutcome::Dynamic(behavior) => dynamic_usages.record(behavior),
+            PatternOutcome::NoMatch => {}
         }
-        if let Some(f) =
-            process_second_arg_pattern(m, &caps, bytes, &aliases, &constants, line_offset)
-        {
-            findings.push(f);
+        match process_second_arg_pattern(m, &caps, bytes, &aliases, &scope, line_offset) {
+            PatternOutcome::Found(f) => findings.push(f),
+            PatternOutcome::Dynamic(behavior) => dynamic_usages.record(behavior),
+            PatternOutcome::NoMatch => {}
         }
         if let Some(f) = process_specta_call(m, &caps, bytes, content, line_offset) {
             findings.push(f);
@@ -181,7 +240,10 @@ pub fn parse_frontend(
         }
     }
 
-    Ok(findings)
+    Ok(FrontendParse {
+        findings,
+        dynamic_usages,
+    })
 }
 
 fn collect_aliases<'a>(
@@ -221,87 +283,103 @@ fn collect_aliases<'a>(
     aliases
 }
 
+/// Read the string a name argument denotes, plus the range to attach findings to.
+///
+/// Outcome of reading the name argument of a Tauri call.
+enum ArgResolution {
+    /// A name was recovered, together with the range to anchor findings to.
+    Resolved(String, Range),
+    /// The argument is a literal but names nothing — `emit("")`. There is no
+    /// entity to index and, crucially, nothing unknown either: an empty literal
+    /// must not weaken the diagnostics the way a genuinely dynamic name does.
+    EmptyLiteral,
+    /// The argument is not a literal and cannot be traced to one.
+    Unresolved,
+}
+
+fn resolve_name_argument(
+    arg: tree_sitter::Node<'_>,
+    bytes: &[u8],
+    scope: &Scope<'_>,
+) -> ArgResolution {
+    let raw = arg.utf8_text(bytes).unwrap_or_default();
+
+    let range = Range {
+        start: point_to_position(arg.start_position()),
+        end: point_to_position(arg.end_position()),
+    };
+
+    if arg.kind() != "string" {
+        return scope
+            .resolve(raw)
+            .map_or(ArgResolution::Unresolved, |name| {
+                ArgResolution::Resolved(name, range)
+            });
+    }
+
+    if let Some(fragment) = arg.named_child(0) {
+        return ArgResolution::Resolved(
+            fragment.utf8_text(bytes).unwrap_or_default().to_string(),
+            Range {
+                start: point_to_position(fragment.start_position()),
+                end: point_to_position(fragment.end_position()),
+            },
+        );
+    }
+
+    // An empty literal has no fragment child, so strip the quotes to confirm it.
+    let unquoted = raw
+        .strip_prefix(['"', '\'', '`'])
+        .and_then(|s| s.strip_suffix(['"', '\'', '`']))
+        .unwrap_or(raw);
+
+    if unquoted.is_empty() {
+        return ArgResolution::EmptyLiteral;
+    }
+
+    ArgResolution::Resolved(unquoted.to_string(), range)
+}
+
 fn process_first_arg_pattern<'a>(
     m: &tree_sitter::QueryMatch<'_, '_>,
     caps: &FrontendCaptures,
     bytes: &'a [u8],
     aliases: &HashMap<&'a str, &'a str>,
-    constants: &HashMap<String, String>,
+    scope: &Scope<'_>,
     content: &str,
     line_offset: usize,
-) -> Option<Finding> {
-    let func_cap = find_capture(m, caps.func_name)?;
-    let arg_cap = find_capture(m, caps.arg_value)?;
+) -> PatternOutcome {
+    let (Some(func_cap), Some(arg_cap)) = (
+        find_capture(m, caps.func_name),
+        find_capture(m, caps.arg_value),
+    ) else {
+        return PatternOutcome::NoMatch;
+    };
 
     let func_name = func_cap.node.utf8_text(bytes).unwrap_or_default();
-    let original_name = *aliases.get(func_name)?;
-
-    let pattern = ALL_FRONTEND_PATTERNS
-        .iter()
-        .find(|p| p.name == original_name && p.arg_position == ArgPosition::First)?;
-
-    if original_name == "invoke" && arg_cap.node.kind() != "string" {
-        return None;
-    }
-
-    let mut resolved_arg = arg_cap
-        .node
-        .utf8_text(bytes)
-        .unwrap_or_default()
-        .to_string();
-    if arg_cap.node.kind() == "string" {
-        if let Some(fragment) = arg_cap.node.named_child(0) {
-            resolved_arg = fragment.utf8_text(bytes).unwrap_or_default().to_string();
-        } else {
-            // fallback: strip first and last quotes
-            if (resolved_arg.starts_with('"') && resolved_arg.ends_with('"')
-                || resolved_arg.starts_with('\'') && resolved_arg.ends_with('\'')
-                || resolved_arg.starts_with('`') && resolved_arg.ends_with('`'))
-                && resolved_arg.len() >= 2
-            {
-                resolved_arg = resolved_arg[1..resolved_arg.len() - 1].to_string();
-            }
-        }
-    } else {
-        let mut resolved = false;
-        if let Some(resolved_val) = constants.get(&resolved_arg) {
-            resolved_arg.clone_from(resolved_val);
-            resolved = true;
-        } else {
-            let lookup_key = if resolved_arg.contains('.') {
-                resolved_arg
-                    .split('.')
-                    .next_back()
-                    .unwrap_or(resolved_arg.as_str())
-            } else {
-                resolved_arg.as_str()
-            };
-            if let Some(resolved_val) = constants.get(lookup_key) {
-                resolved_arg.clone_from(resolved_val);
-                resolved = true;
-            }
-        }
-        if !resolved {
-            resolved_arg.clear();
-        }
-    }
-
-    if resolved_arg.is_empty() {
-        return None;
-    }
-
-    let mut range = Range {
-        start: point_to_position(arg_cap.node.start_position()),
-        end: point_to_position(arg_cap.node.end_position()),
+    let Some(original_name) = aliases.get(func_name).copied() else {
+        return PatternOutcome::NoMatch;
     };
-    if arg_cap.node.kind() == "string" {
-        if let Some(fragment) = arg_cap.node.named_child(0) {
-            range = Range {
-                start: point_to_position(fragment.start_position()),
-                end: point_to_position(fragment.end_position()),
-            };
-        }
+
+    let Some(pattern) = ALL_FRONTEND_PATTERNS
+        .iter()
+        .find(|p| p.name == original_name && p.arg_position == ArgPosition::First)
+    else {
+        return PatternOutcome::NoMatch;
+    };
+
+    // `invoke` is deliberately literal-only: a command name assembled at runtime is
+    // still a call we cannot attribute, so it counts as dynamic rather than absent.
+    if original_name == "invoke" && arg_cap.node.kind() != "string" {
+        return PatternOutcome::Dynamic(pattern.behavior);
     }
+
+    let (resolved_arg, range) = match resolve_name_argument(arg_cap.node, bytes, scope) {
+        ArgResolution::Resolved(name, range) => (name, range),
+        ArgResolution::Unresolved => return PatternOutcome::Dynamic(pattern.behavior),
+        ArgResolution::EmptyLiteral => return PatternOutcome::NoMatch,
+    };
+
     let call_name_end = Some(adjust_position(
         point_to_position(func_cap.node.end_position()),
         line_offset,
@@ -311,7 +389,7 @@ fn process_first_arg_pattern<'a>(
     let return_type = type_arg_info.as_ref().map(|i| i.type_text.clone());
     let type_arg_range = type_arg_info.map(|i| adjust_range(i.type_arg_range, line_offset));
 
-    Some(Finding {
+    PatternOutcome::Found(Finding {
         return_type,
         call_name_end,
         type_arg_range,
@@ -329,79 +407,35 @@ fn process_second_arg_pattern<'a>(
     caps: &FrontendCaptures,
     bytes: &'a [u8],
     aliases: &HashMap<&'a str, &'a str>,
-    constants: &HashMap<String, String>,
+    scope: &Scope<'_>,
     line_offset: usize,
-) -> Option<Finding> {
-    let func_cap = find_capture(m, caps.func_name_second)?;
-    let arg_cap = find_capture(m, caps.arg_value_second)?;
+) -> PatternOutcome {
+    let (Some(func_cap), Some(arg_cap)) = (
+        find_capture(m, caps.func_name_second),
+        find_capture(m, caps.arg_value_second),
+    ) else {
+        return PatternOutcome::NoMatch;
+    };
 
     let func_name = func_cap.node.utf8_text(bytes).unwrap_or_default();
-    let original_name = *aliases.get(func_name)?;
-
-    let pattern = ALL_FRONTEND_PATTERNS
-        .iter()
-        .find(|p| p.name == original_name && p.arg_position == ArgPosition::Second)?;
-
-    let mut resolved_arg = arg_cap
-        .node
-        .utf8_text(bytes)
-        .unwrap_or_default()
-        .to_string();
-    if arg_cap.node.kind() == "string" {
-        if let Some(fragment) = arg_cap.node.named_child(0) {
-            resolved_arg = fragment.utf8_text(bytes).unwrap_or_default().to_string();
-        } else {
-            // fallback: strip first and last quotes
-            if (resolved_arg.starts_with('"') && resolved_arg.ends_with('"')
-                || resolved_arg.starts_with('\'') && resolved_arg.ends_with('\'')
-                || resolved_arg.starts_with('`') && resolved_arg.ends_with('`'))
-                && resolved_arg.len() >= 2
-            {
-                resolved_arg = resolved_arg[1..resolved_arg.len() - 1].to_string();
-            }
-        }
-    } else {
-        let mut resolved = false;
-        if let Some(resolved_val) = constants.get(&resolved_arg) {
-            resolved_arg.clone_from(resolved_val);
-            resolved = true;
-        } else {
-            let lookup_key = if resolved_arg.contains('.') {
-                resolved_arg
-                    .split('.')
-                    .next_back()
-                    .unwrap_or(resolved_arg.as_str())
-            } else {
-                resolved_arg.as_str()
-            };
-            if let Some(resolved_val) = constants.get(lookup_key) {
-                resolved_arg.clone_from(resolved_val);
-                resolved = true;
-            }
-        }
-        if !resolved {
-            resolved_arg.clear();
-        }
-    }
-
-    if resolved_arg.is_empty() {
-        return None;
-    }
-
-    let mut range = Range {
-        start: point_to_position(arg_cap.node.start_position()),
-        end: point_to_position(arg_cap.node.end_position()),
+    let Some(original_name) = aliases.get(func_name).copied() else {
+        return PatternOutcome::NoMatch;
     };
-    if arg_cap.node.kind() == "string" {
-        if let Some(fragment) = arg_cap.node.named_child(0) {
-            range = Range {
-                start: point_to_position(fragment.start_position()),
-                end: point_to_position(fragment.end_position()),
-            };
-        }
-    }
 
-    Some(Finding::new(
+    let Some(pattern) = ALL_FRONTEND_PATTERNS
+        .iter()
+        .find(|p| p.name == original_name && p.arg_position == ArgPosition::Second)
+    else {
+        return PatternOutcome::NoMatch;
+    };
+
+    let (resolved_arg, range) = match resolve_name_argument(arg_cap.node, bytes, scope) {
+        ArgResolution::Resolved(name, range) => (name, range),
+        ArgResolution::Unresolved => return PatternOutcome::Dynamic(pattern.behavior),
+        ArgResolution::EmptyLiteral => return PatternOutcome::NoMatch,
+    };
+
+    PatternOutcome::Found(Finding::new(
         resolved_arg,
         pattern.entity,
         pattern.behavior,

--- a/lsp-server/src/parser/typescript/frontend.rs
+++ b/lsp-server/src/parser/typescript/frontend.rs
@@ -1,6 +1,6 @@
 //! TypeScript/JavaScript/Vue/Svelte/Angular parsing for Tauri invoke/emit/listen calls
 
-use crate::indexer::{DynamicUsages, Finding};
+use crate::indexer::{DynamicUsages, Finding, Forwarder};
 use crate::syntax::{Behavior, EntityType, ParseError, ParseResult};
 use crate::utils::{find_capture, point_to_position};
 use std::collections::HashMap;
@@ -63,9 +63,12 @@ static ALL_FRONTEND_PATTERNS: LazyLock<Vec<FunctionPatternWithPos>> = LazyLock::
 });
 
 /// Result of parsing one frontend file.
+#[derive(Default)]
 pub struct FrontendParse {
     pub findings: Vec<Finding>,
     pub dynamic_usages: DynamicUsages,
+    /// Forwarding helpers this file declares.
+    pub forwarders: Vec<Forwarder>,
 }
 
 /// Everything needed to turn a command/event name argument into a literal.
@@ -112,10 +115,93 @@ impl Scope<'_> {
 enum PatternOutcome {
     /// The match is a Tauri call with a known command/event name.
     Found(Finding),
+    /// The match is a Tauri call that forwards a parameter of the enclosing helper.
+    /// The name lives at the helper's call sites, not here.
+    Forwards(Forwarder),
     /// The match is a Tauri call whose name could not be resolved to a literal.
     Dynamic(Behavior),
     /// The match is not a Tauri call at all.
     NoMatch,
+}
+
+/// Node kinds that introduce a parameter list.
+const FUNCTION_KINDS: [&str; 5] = [
+    "arrow_function",
+    "function_declaration",
+    "function_expression",
+    "method_definition",
+    "generator_function_declaration",
+];
+
+/// If `name` is a parameter of a *named* function enclosing `node`, describe how
+/// that function forwards it into a Tauri call.
+///
+/// Anonymous callbacks are skipped: with no name there is no call site to look up.
+fn detect_forwarder(
+    node: tree_sitter::Node<'_>,
+    name: &str,
+    bytes: &[u8],
+    entity: EntityType,
+    behavior: Behavior,
+) -> Option<Forwarder> {
+    let mut current = node.parent();
+
+    while let Some(candidate) = current {
+        if FUNCTION_KINDS.contains(&candidate.kind()) {
+            if let Some(param_index) = parameter_index(candidate, name, bytes) {
+                return function_name(candidate, bytes).map(|function_name| Forwarder {
+                    function_name,
+                    param_index,
+                    entity,
+                    behavior,
+                });
+            }
+
+            // The name belongs to an outer scope; keep walking outwards.
+        }
+
+        current = candidate.parent();
+    }
+
+    None
+}
+
+/// Position of the parameter called `name` in a function's parameter list.
+fn parameter_index(function: tree_sitter::Node<'_>, name: &str, bytes: &[u8]) -> Option<usize> {
+    // `const f = event => ...` has a single unparenthesized parameter.
+    if let Some(single) = function.child_by_field_name("parameter") {
+        return (single.utf8_text(bytes).unwrap_or_default() == name).then_some(0);
+    }
+
+    let params = function.child_by_field_name("parameters")?;
+    let mut cursor = params.walk();
+    let declared: Vec<_> = params.named_children(&mut cursor).collect();
+
+    declared.iter().position(|param| {
+        let mut bound = std::collections::HashSet::new();
+        crate::utils::collect_parameter_names(*param, bytes, &mut bound);
+
+        bound.contains(name)
+    })
+}
+
+/// Name a function can be called by: its own identifier, or the variable it is
+/// assigned to for arrow and function expressions.
+fn function_name(function: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
+    if let Some(own_name) = function.child_by_field_name("name") {
+        return Some(own_name.utf8_text(bytes).unwrap_or_default().to_string());
+    }
+
+    let declarator = function.parent()?;
+
+    if declarator.kind() != "variable_declarator" {
+        return None;
+    }
+
+    let name_node = declarator.child_by_field_name("name")?;
+
+    (name_node.kind() == "identifier")
+        .then(|| name_node.utf8_text(bytes).unwrap_or_default().to_string())
 }
 
 /// Capture indices extracted from the query, grouped for readability
@@ -133,6 +219,8 @@ struct FrontendCaptures {
     specta_call: Option<u32>,
     specta_event_name: Option<u32>,
     specta_event_method: Option<u32>,
+    plain_fn: Option<u32>,
+    plain_args: Option<u32>,
 }
 
 impl FrontendCaptures {
@@ -151,6 +239,8 @@ impl FrontendCaptures {
             specta_call: query.capture_index_for_name("specta_call"),
             specta_event_name: query.capture_index_for_name("specta_event_name"),
             specta_event_method: query.capture_index_for_name("specta_event_method"),
+            plain_fn: query.capture_index_for_name("plain_fn"),
+            plain_args: query.capture_index_for_name("plain_args"),
         }
     }
 }
@@ -166,6 +256,7 @@ pub fn parse_frontend(
     lang: LangType,
     line_offset: usize,
     global_constants: &HashMap<String, String>,
+    known_forwarders: &HashMap<String, Forwarder>,
 ) -> ParseResult<FrontendParse> {
     let ts_lang: Language = match lang {
         LangType::JavaScript | LangType::JavaScriptJsx => tree_sitter_javascript::LANGUAGE.into(),
@@ -218,17 +309,20 @@ pub fn parse_frontend(
     // Second pass: collect function calls
     let mut findings = Vec::new();
     let mut dynamic_usages = DynamicUsages::default();
+    let mut forwarders = Vec::new();
     let mut cursor = QueryCursor::new();
     let mut matches = cursor.matches(&query, root, bytes);
 
     while let Some(m) = matches.next() {
         match process_first_arg_pattern(m, &caps, bytes, &aliases, &scope, content, line_offset) {
             PatternOutcome::Found(f) => findings.push(f),
+            PatternOutcome::Forwards(fwd) => forwarders.push(fwd),
             PatternOutcome::Dynamic(behavior) => dynamic_usages.record(behavior),
             PatternOutcome::NoMatch => {}
         }
         match process_second_arg_pattern(m, &caps, bytes, &aliases, &scope, line_offset) {
             PatternOutcome::Found(f) => findings.push(f),
+            PatternOutcome::Forwards(fwd) => forwarders.push(fwd),
             PatternOutcome::Dynamic(behavior) => dynamic_usages.record(behavior),
             PatternOutcome::NoMatch => {}
         }
@@ -238,12 +332,155 @@ pub fn parse_frontend(
         if let Some(f) = process_specta_event(m, &caps, bytes, line_offset) {
             findings.push(f);
         }
+        match process_forwarder_call(m, &caps, bytes, &scope, known_forwarders, line_offset) {
+            PatternOutcome::Found(f) => findings.push(f),
+            PatternOutcome::Dynamic(behavior) => dynamic_usages.record(behavior),
+            PatternOutcome::Forwards(_) | PatternOutcome::NoMatch => {}
+        }
     }
 
     Ok(FrontendParse {
         findings,
         dynamic_usages,
+        forwarders,
     })
+}
+
+/// Collect only the forwarding helpers a file declares.
+///
+/// The main pass cannot do this on its own: a call site is resolvable only once the
+/// helper it calls is known, and helpers are routinely declared in another file.
+/// This runs alongside the constant pre-pass and deliberately skips everything the
+/// declaration scan does not need — constants, bound names, specta, findings.
+///
+/// # Errors
+///
+/// Returns error if tree-sitter fails to parse the file or query execution fails.
+pub fn extract_forwarders(content: &str, lang: LangType) -> ParseResult<Vec<Forwarder>> {
+    let ts_lang: Language = match lang {
+        LangType::JavaScript | LangType::JavaScriptJsx => tree_sitter_javascript::LANGUAGE.into(),
+        LangType::TypeScriptJsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        _ => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+    };
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&ts_lang)
+        .map_err(|e| ParseError::LanguageError(format!("Failed to set {lang:?} language: {e}")))?;
+
+    let tree = parser
+        .parse(content, None)
+        .ok_or_else(|| ParseError::SyntaxError(format!("Failed to parse {lang:?} file")))?;
+
+    if tree.root_node().has_error() {
+        return Ok(Vec::new());
+    }
+
+    let query = Query::new(&ts_lang, get_query_source(lang))
+        .map_err(|e| ParseError::QueryError(format!("Failed to create {lang:?} query: {e}")))?;
+
+    let caps = FrontendCaptures::from_query(&query);
+    let root = tree.root_node();
+    let bytes = content.as_bytes();
+    let aliases = collect_aliases(&query, root, bytes, &caps);
+
+    let mut forwarders = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, root, bytes);
+
+    while let Some(m) = matches.next() {
+        for (func_cap, arg_cap, position) in [
+            (caps.func_name, caps.arg_value, ArgPosition::First),
+            (
+                caps.func_name_second,
+                caps.arg_value_second,
+                ArgPosition::Second,
+            ),
+        ] {
+            let (Some(func_cap), Some(arg_cap)) =
+                (find_capture(m, func_cap), find_capture(m, arg_cap))
+            else {
+                continue;
+            };
+
+            // Only a bare identifier can be a forwarded parameter.
+            if arg_cap.node.kind() != "identifier" {
+                continue;
+            }
+
+            let func_name = func_cap.node.utf8_text(bytes).unwrap_or_default();
+            let Some(original_name) = aliases.get(func_name).copied() else {
+                continue;
+            };
+
+            let Some(pattern) = ALL_FRONTEND_PATTERNS
+                .iter()
+                .find(|p| p.name == original_name && p.arg_position == position)
+            else {
+                continue;
+            };
+
+            let raw = arg_cap.node.utf8_text(bytes).unwrap_or_default();
+
+            if let Some(forwarder) =
+                detect_forwarder(arg_cap.node, raw, bytes, pattern.entity, pattern.behavior)
+            {
+                forwarders.push(forwarder);
+            }
+        }
+    }
+
+    Ok(forwarders)
+}
+
+/// Turn a call of a known forwarding helper into a finding for the real command
+/// or event, anchored at the literal in *this* file.
+///
+/// This is what makes `emitToOverlays("units-changed", value)` navigable: the
+/// finding is indexed exactly as if `emit("units-changed", ...)` were written here.
+fn process_forwarder_call(
+    m: &tree_sitter::QueryMatch<'_, '_>,
+    caps: &FrontendCaptures,
+    bytes: &[u8],
+    scope: &Scope<'_>,
+    known_forwarders: &HashMap<String, Forwarder>,
+    line_offset: usize,
+) -> PatternOutcome {
+    let (Some(fn_cap), Some(args_cap)) = (
+        find_capture(m, caps.plain_fn),
+        find_capture(m, caps.plain_args),
+    ) else {
+        return PatternOutcome::NoMatch;
+    };
+
+    let called = fn_cap.node.utf8_text(bytes).unwrap_or_default();
+    let Some(forwarder) = known_forwarders.get(called) else {
+        return PatternOutcome::NoMatch;
+    };
+
+    // A helper declared in this file is also matched here; that is intended, since
+    // its own body forwards a parameter and produces no finding of its own.
+    let mut cursor = args_cap.node.walk();
+    let Some(name_arg) = args_cap
+        .node
+        .named_children(&mut cursor)
+        .nth(forwarder.param_index)
+    else {
+        return PatternOutcome::Dynamic(forwarder.behavior);
+    };
+
+    match resolve_name_argument(name_arg, bytes, scope) {
+        ArgResolution::Resolved(name, range) => PatternOutcome::Found(Finding::new(
+            name,
+            forwarder.entity,
+            forwarder.behavior,
+            adjust_range(range, line_offset),
+        )),
+        // A forwarder fed by another forwarder's parameter would need a second
+        // hop; one level is resolved, deeper chains stay unprovable.
+        ArgResolution::Unresolved => PatternOutcome::Dynamic(forwarder.behavior),
+        ArgResolution::EmptyLiteral => PatternOutcome::NoMatch,
+    }
 }
 
 fn collect_aliases<'a>(
@@ -368,15 +605,28 @@ fn process_first_arg_pattern<'a>(
         return PatternOutcome::NoMatch;
     };
 
-    // `invoke` is deliberately literal-only: a command name assembled at runtime is
-    // still a call we cannot attribute, so it counts as dynamic rather than absent.
+    // `invoke` is deliberately literal-only — a command name is never resolved
+    // through the constant table. A forwarded parameter is different: the literal
+    // does exist, at the helper's call sites, so it is still worth recovering.
     if original_name == "invoke" && arg_cap.node.kind() != "string" {
-        return PatternOutcome::Dynamic(pattern.behavior);
+        let raw = arg_cap.node.utf8_text(bytes).unwrap_or_default();
+
+        return detect_forwarder(arg_cap.node, raw, bytes, pattern.entity, pattern.behavior)
+            .map_or(PatternOutcome::Dynamic(pattern.behavior), |forwarder| {
+                PatternOutcome::Forwards(forwarder)
+            });
     }
 
     let (resolved_arg, range) = match resolve_name_argument(arg_cap.node, bytes, scope) {
         ArgResolution::Resolved(name, range) => (name, range),
-        ArgResolution::Unresolved => return PatternOutcome::Dynamic(pattern.behavior),
+        ArgResolution::Unresolved => {
+            let raw = arg_cap.node.utf8_text(bytes).unwrap_or_default();
+
+            return detect_forwarder(arg_cap.node, raw, bytes, pattern.entity, pattern.behavior)
+                .map_or(PatternOutcome::Dynamic(pattern.behavior), |forwarder| {
+                    PatternOutcome::Forwards(forwarder)
+                });
+        }
         ArgResolution::EmptyLiteral => return PatternOutcome::NoMatch,
     };
 
@@ -431,7 +681,14 @@ fn process_second_arg_pattern<'a>(
 
     let (resolved_arg, range) = match resolve_name_argument(arg_cap.node, bytes, scope) {
         ArgResolution::Resolved(name, range) => (name, range),
-        ArgResolution::Unresolved => return PatternOutcome::Dynamic(pattern.behavior),
+        ArgResolution::Unresolved => {
+            let raw = arg_cap.node.utf8_text(bytes).unwrap_or_default();
+
+            return detect_forwarder(arg_cap.node, raw, bytes, pattern.entity, pattern.behavior)
+                .map_or(PatternOutcome::Dynamic(pattern.behavior), |forwarder| {
+                    PatternOutcome::Forwards(forwarder)
+                });
+        }
         ArgResolution::EmptyLiteral => return PatternOutcome::NoMatch,
     };
 

--- a/lsp-server/src/parser/typescript/frontend.rs
+++ b/lsp-server/src/parser/typescript/frontend.rs
@@ -534,6 +534,21 @@ enum ArgResolution {
     Unresolved,
 }
 
+/// Whether the node spells a name out in full.
+///
+/// A template literal qualifies as long as nothing is interpolated: `` `greet` ``
+/// names a command every bit as plainly as `"greet"`, while `` `get_${kind}` ``
+/// is as dynamic as a bare identifier.
+fn is_literal_name_node(node: tree_sitter::Node<'_>) -> bool {
+    match node.kind() {
+        "string" => true,
+        "template_string" => !node
+            .named_children(&mut node.walk())
+            .any(|child| child.kind() == "template_substitution"),
+        _ => false,
+    }
+}
+
 fn resolve_name_argument(
     arg: tree_sitter::Node<'_>,
     bytes: &[u8],
@@ -546,7 +561,7 @@ fn resolve_name_argument(
         end: point_to_position(arg.end_position()),
     };
 
-    if arg.kind() != "string" {
+    if !is_literal_name_node(arg) {
         return scope
             .resolve(raw)
             .map_or(ArgResolution::Unresolved, |name| {
@@ -608,7 +623,7 @@ fn process_first_arg_pattern<'a>(
     // `invoke` is deliberately literal-only — a command name is never resolved
     // through the constant table. A forwarded parameter is different: the literal
     // does exist, at the helper's call sites, so it is still worth recovering.
-    if original_name == "invoke" && arg_cap.node.kind() != "string" {
+    if original_name == "invoke" && !is_literal_name_node(arg_cap.node) {
         let raw = arg_cap.node.utf8_text(bytes).unwrap_or_default();
 
         return detect_forwarder(arg_cap.node, raw, bytes, pattern.entity, pattern.behavior)

--- a/lsp-server/src/parser/typescript/frontend.rs
+++ b/lsp-server/src/parser/typescript/frontend.rs
@@ -372,10 +372,10 @@ pub fn extract_forwarders(content: &str, lang: LangType) -> ParseResult<Vec<Forw
         .parse(content, None)
         .ok_or_else(|| ParseError::SyntaxError(format!("Failed to parse {lang:?} file")))?;
 
-    if tree.root_node().has_error() {
-        return Ok(Vec::new());
-    }
-
+    // No `has_error` bail-out here: helpers are cross-file, so discarding every
+    // declaration in a file that is merely mid-edit would silently turn each of its
+    // call sites elsewhere into an unresolved dynamic usage. Tree-sitter still
+    // recovers the intact subtrees, and the main pass parses on the same terms.
     let query = Query::new(&ts_lang, get_query_source(lang))
         .map_err(|e| ParseError::QueryError(format!("Failed to create {lang:?} query: {e}")))?;
 

--- a/lsp-server/src/pipeline.rs
+++ b/lsp-server/src/pipeline.rs
@@ -70,6 +70,12 @@ pub fn process_file_content(path: &Path, content: &str, project_index: &ProjectI
         let local_constants = crate::utils::extract_js_constants_from_content(content, is_js);
         project_index.add_js_constants(path.to_path_buf(), local_constants);
         let global_constants = project_index.get_all_js_constants();
+
+        // Re-register this file's helpers before the main pass reads the global set:
+        // an edit that declares a helper and calls it in the same file would otherwise
+        // be parsed against the pre-edit snapshot and leave the call site unresolved.
+        project_index.add_forwarders(path.to_path_buf(), extract_file_forwarders(path, content));
+
         let known_forwarders = project_index.get_all_forwarders();
 
         match parser::parse(path, content, &global_constants, &known_forwarders) {
@@ -190,16 +196,42 @@ pub fn collect_constants_from_file(path: &Path, project_index: &ProjectIndex) {
 
         // Forwarding helpers are cross-file: a call site is only resolvable once the
         // helper that owns it is known, so they must be collected before the main pass.
-        if let Some(lang) = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .and_then(parser::LangType::from_extension)
-        {
-            if let Ok(forwarders) = parser::typescript::frontend::extract_forwarders(&content, lang)
-            {
-                project_index.add_forwarders(path.to_path_buf(), forwarders);
-            }
+        project_index.add_forwarders(path.to_path_buf(), extract_file_forwarders(path, &content));
+    }
+}
+
+/// Forwarding helpers declared by a single frontend file.
+///
+/// Returns an empty list for anything that is not a frontend language. SFCs are
+/// unwrapped to their script blocks first, since the helper scan reads plain
+/// TypeScript and would otherwise see the surrounding template markup.
+fn extract_file_forwarders(path: &Path, content: &str) -> Vec<crate::indexer::types::Forwarder> {
+    let Some(lang) = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .and_then(parser::LangType::from_extension)
+    else {
+        return Vec::new();
+    };
+
+    match lang {
+        parser::LangType::Rust => Vec::new(),
+
+        parser::LangType::Vue | parser::LangType::Svelte => {
+            parser::typescript::sfc::extract_script_blocks(content)
+                .into_iter()
+                .filter_map(|(script, _)| {
+                    parser::typescript::frontend::extract_forwarders(
+                        &script,
+                        parser::LangType::TypeScript,
+                    )
+                    .ok()
+                })
+                .flatten()
+                .collect()
         }
+
+        _ => parser::typescript::frontend::extract_forwarders(content, lang).unwrap_or_default(),
     }
 }
 
@@ -228,6 +260,34 @@ mod tests {
         let fixtures_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
         std::fs::read_to_string(fixtures_dir.join(relative_path))
             .unwrap_or_else(|e| panic!("Failed to load fixture {relative_path}: {e}"))
+    }
+
+    #[test]
+    fn test_helper_declared_and_called_in_same_edit_is_indexed() {
+        // Simulates `didChange`: the file introduces the helper and a call to it at
+        // once, so nothing else in the workspace has registered the forwarder yet.
+        let index = ProjectIndex::new();
+        let path = PathBuf::from("app.ts");
+
+        let content = r#"
+import { emit } from "@tauri-apps/api/event";
+
+const broadcast = (event: string, payload: unknown) => emit(event, payload);
+
+broadcast("units-changed", "metric");
+"#;
+
+        assert!(process_file_content(&path, content, &index));
+
+        let key = crate::indexer::types::IndexKey {
+            entity: crate::syntax::EntityType::Event,
+            name: "units-changed".to_string(),
+        };
+
+        assert!(
+            index.map.contains_key(&key),
+            "call site of a helper declared in the same edit should be indexed"
+        );
     }
 
     #[test]

--- a/lsp-server/src/pipeline.rs
+++ b/lsp-server/src/pipeline.rs
@@ -70,8 +70,9 @@ pub fn process_file_content(path: &Path, content: &str, project_index: &ProjectI
         let local_constants = crate::utils::extract_js_constants_from_content(content, is_js);
         project_index.add_js_constants(path.to_path_buf(), local_constants);
         let global_constants = project_index.get_all_js_constants();
+        let known_forwarders = project_index.get_all_forwarders();
 
-        match parser::parse(path, content, &global_constants) {
+        match parser::parse(path, content, &global_constants, &known_forwarders) {
             Ok(file_index) => {
                 project_index.add_file(file_index);
 
@@ -186,6 +187,19 @@ pub fn collect_constants_from_file(path: &Path, project_index: &ProjectIndex) {
         let is_js = path.extension().is_some_and(|e| e == "js" || e == "jsx");
         let constants = crate::utils::extract_js_constants_from_content(&content, is_js);
         project_index.add_js_constants(path.to_path_buf(), constants);
+
+        // Forwarding helpers are cross-file: a call site is only resolvable once the
+        // helper that owns it is known, so they must be collected before the main pass.
+        if let Some(lang) = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .and_then(parser::LangType::from_extension)
+        {
+            if let Ok(forwarders) = parser::typescript::frontend::extract_forwarders(&content, lang)
+            {
+                project_index.add_forwarders(path.to_path_buf(), forwarders);
+            }
+        }
     }
 }
 

--- a/lsp-server/src/queries/javascript.scm
+++ b/lsp-server/src/queries/javascript.scm
@@ -7,7 +7,7 @@
   function: (identifier) @func_name
   arguments: (arguments
     .
-    (string) @arg_value)
+    [(string) (template_string)] @arg_value)
 ) @call_simple
 
 (call_expression
@@ -30,7 +30,7 @@
   arguments: (arguments
     (_)
     .
-    (string) @arg_value_second)
+    [(string) (template_string)] @arg_value_second)
 ) @call_second_arg
 
 (call_expression

--- a/lsp-server/src/queries/javascript.scm
+++ b/lsp-server/src/queries/javascript.scm
@@ -108,3 +108,9 @@
     property: (property_identifier) @specta_event_method)
   (#eq? @_specta_events_obj "events")
 ) @specta_event_call
+
+; === PLAIN CALLS (candidate forwarding helpers) ===
+(call_expression
+  function: (identifier) @plain_fn
+  arguments: (arguments) @plain_args
+)

--- a/lsp-server/src/queries/typescript.scm
+++ b/lsp-server/src/queries/typescript.scm
@@ -37,7 +37,7 @@
   !type_arguments
   arguments: (arguments
     .
-    (string) @arg_value)
+    [(string) (template_string)] @arg_value)
 ) @call_simple
 
 (call_expression
@@ -63,7 +63,7 @@
   !type_arguments
   arguments: (arguments
     .
-    (string) @arg_value)
+    [(string) (template_string)] @arg_value)
 ) @call_await_simple
 
 (call_expression
@@ -91,7 +91,7 @@
   arguments: (arguments
     (_)
     .
-    (string) @arg_value_second)
+    [(string) (template_string)] @arg_value_second)
 ) @call_second_arg
 
 (call_expression
@@ -120,7 +120,7 @@
   arguments: (arguments
     (_)
     .
-    (string) @arg_value_second)
+    [(string) (template_string)] @arg_value_second)
 ) @call_await_second_arg
 
 (call_expression
@@ -151,7 +151,7 @@
   type_arguments: (type_arguments)
   arguments: (arguments
     .
-    (string) @arg_value)
+    [(string) (template_string)] @arg_value)
 ) @call_generic
 
 (call_expression
@@ -177,7 +177,7 @@
   type_arguments: (type_arguments)
   arguments: (arguments
     .
-    (string) @arg_value)
+    [(string) (template_string)] @arg_value)
 ) @call_await_generic
 
 (call_expression
@@ -205,7 +205,7 @@
   arguments: (arguments
     (_)
     .
-    (string) @arg_value_second)
+    [(string) (template_string)] @arg_value_second)
 ) @call_generic_second_arg
 
 (call_expression
@@ -234,7 +234,7 @@
   arguments: (arguments
     (_)
     .
-    (string) @arg_value_second)
+    [(string) (template_string)] @arg_value_second)
 ) @call_await_generic_second_arg
 
 (call_expression

--- a/lsp-server/src/queries/typescript.scm
+++ b/lsp-server/src/queries/typescript.scm
@@ -290,3 +290,10 @@
     property: (property_identifier) @specta_event_method)
   (#eq? @_specta_events_obj "events")
 ) @specta_event_call
+
+; === PLAIN CALLS (candidate forwarding helpers) ===
+; Any bare call; only those naming a known forwarder are acted upon.
+(call_expression
+  function: (identifier) @plain_fn
+  arguments: (arguments) @plain_args
+)

--- a/lsp-server/src/utils/mod.rs
+++ b/lsp-server/src/utils/mod.rs
@@ -169,6 +169,22 @@ pub fn collect_bound_names(root: tree_sitter::Node<'_>, content: &str) -> HashSe
     bound
 }
 
+/// Add every identifier a single parameter binds to `bound`, unwrapping type
+/// annotations, defaults and destructuring patterns.
+#[allow(clippy::implicit_hasher)] // reason: callers use the default hasher throughout
+pub fn collect_parameter_names(
+    param: tree_sitter::Node<'_>,
+    bytes: &[u8],
+    bound: &mut HashSet<String>,
+) {
+    match param.kind() {
+        "required_parameter" | "optional_parameter" => {
+            collect_pattern_names(param.child_by_field_name("pattern"), bytes, bound);
+        }
+        _ => collect_pattern_names(Some(param), bytes, bound),
+    }
+}
+
 /// Add the identifiers introduced by a binding pattern (plain, object or array
 /// destructuring) to `bound`.
 fn collect_pattern_names(

--- a/lsp-server/src/utils/mod.rs
+++ b/lsp-server/src/utils/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod ts_tree_utils;
 
+use std::collections::HashSet;
 use std::sync::LazyLock;
 use streaming_iterator::StreamingIterator;
 use tower_lsp_server::lsp_types::{Position, Range};
@@ -122,6 +123,74 @@ pub fn extract_rust_constants(
         }
     }
     constants
+}
+
+/// Collect every identifier the file binds itself: function parameters, catch
+/// clauses and variable declarators.
+///
+/// A name bound here shadows any same-named constant found elsewhere in the
+/// workspace, so cross-file constant resolution must not be applied to it. Scopes
+/// are deliberately not modelled — the whole file is treated as one scope, which
+/// can only make resolution give up, never invent a wrong name.
+#[must_use]
+pub fn collect_bound_names(root: tree_sitter::Node<'_>, content: &str) -> HashSet<String> {
+    let mut bound = HashSet::new();
+    let bytes = content.as_bytes();
+    let mut cursor = root.walk();
+    let mut stack = vec![root];
+
+    while let Some(node) = stack.pop() {
+        match node.kind() {
+            "required_parameter" | "optional_parameter" => {
+                collect_pattern_names(node.child_by_field_name("pattern"), bytes, &mut bound);
+            }
+            "arrow_function" => {
+                collect_pattern_names(node.child_by_field_name("parameter"), bytes, &mut bound);
+            }
+            "variable_declarator" | "catch_clause" => {
+                collect_pattern_names(node.child_by_field_name("name"), bytes, &mut bound);
+                collect_pattern_names(node.child_by_field_name("parameter"), bytes, &mut bound);
+            }
+            "formal_parameters" => {
+                for child in node.named_children(&mut node.walk()) {
+                    if child.kind() == "identifier" {
+                        collect_pattern_names(Some(child), bytes, &mut bound);
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        for child in node.named_children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+
+    bound
+}
+
+/// Add the identifiers introduced by a binding pattern (plain, object or array
+/// destructuring) to `bound`.
+fn collect_pattern_names(
+    node: Option<tree_sitter::Node<'_>>,
+    bytes: &[u8],
+    bound: &mut HashSet<String>,
+) {
+    let Some(node) = node else {
+        return;
+    };
+
+    if node.kind() == "identifier" || node.kind() == "shorthand_property_identifier_pattern" {
+        bound.insert(node.utf8_text(bytes).unwrap_or_default().to_string());
+
+        return;
+    }
+
+    let mut cursor = node.walk();
+
+    for child in node.named_children(&mut cursor) {
+        collect_pattern_names(Some(child), bytes, bound);
+    }
 }
 
 /// Extract constant definitions from a JavaScript/TypeScript AST root node

--- a/lsp-server/tests/code_lens_tests.rs
+++ b/lsp-server/tests/code_lens_tests.rs
@@ -100,7 +100,7 @@ $0
 
 #[test]
 fn code_lens_no_cross_file_targets() {
-    // Only Rust file, no frontend files → no lenses (targets must be in other files)
+    // A lone definition has nothing to point at: its own location is never a target.
     helpers::check_code_lens(
         r#"
 //- /backend.rs
@@ -133,5 +133,153 @@ import { listen } from "@tauri-apps/api/event";
 listen<string>("units-changed", (e) => console.log(e.payload));
 "#,
         expect![[r#"7:18 "Go to overlay.ts""#]],
+    );
+}
+
+#[test]
+fn code_lens_same_file_emit_and_listen() {
+    // Both sides live in one file. The lens names the line rather than the file,
+    // which would be tautological, and neither side points at itself.
+    helpers::check_code_lens(
+        r#"
+//- /events.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+emit("units-changed");
+
+listen("units-changed", () => {});
+$0
+"#,
+        expect![[r#"
+            2:6 "Go to line 5"
+            4:8 "Go to line 3""#]],
+    );
+}
+
+#[test]
+fn code_lens_same_file_multiple_references_summarised() {
+    helpers::check_code_lens(
+        r#"
+//- /events.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+emit("units-changed");
+emit("units-changed");
+
+listen("units-changed", () => {});
+$0
+"#,
+        expect![[r#"
+            2:6 "2 in this file"
+            3:6 "2 in this file"
+            5:8 "2 in this file""#]],
+    );
+}
+
+#[test]
+fn code_lens_same_file_lens_is_separate_from_cross_file() {
+    // A cross-file target and a same-file one produce two distinct lenses.
+    helpers::check_code_lens(
+        r#"
+//- /events.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+emit("units-changed");
+
+listen("units-changed", () => {});
+$0
+//- /overlay.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+"#,
+        expect![[r#"
+            2:6 "Go to line 5"
+            2:6 "Go to overlay.ts"
+            4:8 "Go to line 3"
+            4:8 "Go to overlay.ts""#]],
+    );
+}
+
+#[test]
+fn code_lens_same_file_setup_function_and_emitters() {
+    // Shape of a real sync module: listeners registered in a setup function near
+    // the top, emitters exported from the bottom of the same file.
+    helpers::check_code_lens(
+        r#"
+//- /events.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+export const setupListeners = async () => {
+  await listen<boolean>("interact-mode-changed", (e) => console.log(e.payload));
+  await listen<number>("steering-lock-changed", (e) => console.log(e.payload));
+};
+
+export const emitInteractMode = (active: boolean) =>
+  emit("interact-mode-changed", active);
+
+export const resetInteractMode = () => emit("interact-mode-changed", false);
+
+export const emitSteeringLock = (degrees: number) =>
+  emit("steering-lock-changed", degrees);
+$0
+"#,
+        expect![[r#"
+            10:45 "2 in this file"
+            13:8 "Go to line 5"
+            3:25 "2 in this file"
+            4:24 "Go to line 14"
+            8:8 "2 in this file""#]],
+    );
+}
+
+#[test]
+fn code_lens_frontend_summarises_past_reference_limit() {
+    // Four listener files exceed the default limit of three, so the individual
+    // "Go to <file>" links collapse into one summary.
+    helpers::check_code_lens(
+        r#"
+//- /emitter.ts
+import { emit } from "@tauri-apps/api/event";
+emit("units-changed");
+$0
+//- /a.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+
+//- /b.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+
+//- /c.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+
+//- /d.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+"#,
+        expect![[r#"1:6 "4 references""#]],
+    );
+}
+
+#[test]
+fn code_lens_frontend_lists_files_within_reference_limit() {
+    helpers::check_code_lens(
+        r#"
+//- /emitter.ts
+import { emit } from "@tauri-apps/api/event";
+emit("units-changed");
+$0
+//- /a.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+
+//- /b.ts
+import { listen } from "@tauri-apps/api/event";
+listen("units-changed", () => {});
+"#,
+        expect![[r#"
+            1:6 "Go to a.ts"
+            1:6 "Go to b.ts""#]],
     );
 }

--- a/lsp-server/tests/code_lens_tests.rs
+++ b/lsp-server/tests/code_lens_tests.rs
@@ -157,7 +157,9 @@ $0
 }
 
 #[test]
-fn code_lens_same_file_multiple_references_summarised() {
+fn code_lens_same_file_summarises_past_reference_limit() {
+    // Four same-file references exceed the default limit of three, so the
+    // per-line links collapse exactly as the cross-file ones do.
     helpers::check_code_lens(
         r#"
 //- /events.ts
@@ -165,14 +167,18 @@ import { emit, listen } from "@tauri-apps/api/event";
 
 emit("units-changed");
 emit("units-changed");
+emit("units-changed");
+emit("units-changed");
 
 listen("units-changed", () => {});
 $0
 "#,
         expect![[r#"
-            2:6 "2 in this file"
-            3:6 "2 in this file"
-            5:8 "2 in this file""#]],
+            2:6 "4 in this file"
+            3:6 "4 in this file"
+            4:6 "4 in this file"
+            5:6 "4 in this file"
+            7:8 "4 in this file""#]],
     );
 }
 
@@ -224,11 +230,14 @@ export const emitSteeringLock = (degrees: number) =>
 $0
 "#,
         expect![[r#"
-            10:45 "2 in this file"
+            10:45 "Go to line 4"
+            10:45 "Go to line 9"
             13:8 "Go to line 5"
-            3:25 "2 in this file"
+            3:25 "Go to line 11"
+            3:25 "Go to line 9"
             4:24 "Go to line 14"
-            8:8 "2 in this file""#]],
+            8:8 "Go to line 11"
+            8:8 "Go to line 4""#]],
     );
 }
 
@@ -281,5 +290,38 @@ listen("units-changed", () => {});
         expect![[r#"
             1:6 "Go to a.ts"
             1:6 "Go to b.ts""#]],
+    );
+}
+
+#[test]
+fn code_lens_limit_counts_links_across_categories() {
+    // One Rust definition plus three frontend call sites is four links on a single
+    // line. The limit is about how many links a lens shows, so it must count them
+    // all, not restart per category.
+    helpers::check_code_lens(
+        r#"
+//- /backend.rs
+#[tauri::command]
+fn greet() {}
+
+//- /caller.ts
+import { invoke } from "@tauri-apps/api/core";
+invoke("greet");
+$0
+//- /a.ts
+import { invoke } from "@tauri-apps/api/core";
+invoke("greet");
+
+//- /b.ts
+import { invoke } from "@tauri-apps/api/core";
+invoke("greet");
+
+//- /c.ts
+import { invoke } from "@tauri-apps/api/core";
+invoke("greet");
+"#,
+        expect![[r#"
+            1:8 "1 rust ref"
+            1:8 "3 references""#]],
     );
 }

--- a/lsp-server/tests/code_lens_tests.rs
+++ b/lsp-server/tests/code_lens_tests.rs
@@ -111,3 +111,27 @@ $0
         expect!["(none)"],
     );
 }
+
+#[test]
+fn code_lens_forwarded_emit_links_to_listener_file() {
+    // The emit only exists because the helper's parameter was resolved from this
+    // call site; the lens proves that finding reaches navigation like any other.
+    helpers::check_code_lens(
+        r#"
+//- /sync.ts
+import { emitTo } from "@tauri-apps/api/event";
+
+const emitToOverlays = async (event: string, payload: unknown) => {
+  await emitTo("overlay", event, payload);
+};
+
+export const emitUnitsChanged = (system: string) =>
+  emitToOverlays("units-changed", system);
+$0
+//- /overlay.ts
+import { listen } from "@tauri-apps/api/event";
+listen<string>("units-changed", (e) => console.log(e.payload));
+"#,
+        expect![[r#"7:18 "Go to overlay.ts""#]],
+    );
+}

--- a/lsp-server/tests/diagnostics_tests.rs
+++ b/lsp-server/tests/diagnostics_tests.rs
@@ -689,9 +689,9 @@ const emitToOverlays = async (event: string, payload: unknown) => {
 }
 
 #[test]
-fn diag_dynamic_emit_suppresses_never_emitted() {
-    // The event name reaches `emitTo` through a wrapper parameter, so the emit
-    // cannot be attributed and "never emitted" can no longer be proven.
+fn diag_forwarded_emit_reaches_the_listener() {
+    // The literal lives at the helper call site; resolving the forwarder links it
+    // to the listener, so there is nothing to report and navigation works.
     helpers::check_diagnostics(
         r#"
 //- /sync.ts
@@ -701,7 +701,47 @@ const emitToOverlays = async (event: string, payload: unknown) => {
   await emitTo("overlay", event, payload);
 };
 
+export const emitUnits = (value: string) => emitToOverlays("units-changed", value);
+
 listen("$0units-changed", () => {});
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_forwarder_called_with_a_variable_stays_unprovable() {
+    // Here even the call site has no literal, so the emit is genuinely unknown and
+    // "never emitted" cannot be proven.
+    helpers::check_diagnostics(
+        r#"
+//- /sync.ts
+import { emitTo, listen } from "@tauri-apps/api/event";
+
+const emitToOverlays = async (event: string, payload: unknown) => {
+  await emitTo("overlay", event, payload);
+};
+
+export const relay = (name: string, value: unknown) => emitToOverlays(name, value);
+
+listen("$0units-changed", () => {});
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_forwarded_listen_reaches_the_emitter() {
+    helpers::check_diagnostics(
+        r#"
+//- /sync.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+const subscribe = (event: string) => listen(event, () => {});
+
+export const watchUnits = () => subscribe("units-changed");
+
+emit("$0units-changed");
 "#,
         expect!["(none)"],
     );
@@ -716,7 +756,28 @@ import { emit, listen } from "@tauri-apps/api/event";
 
 const subscribe = (event: string) => listen(event, () => {});
 
+export const watchAny = (name: string) => subscribe(name);
+
 emit("$0units-changed");
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_forwarded_invoke_reaches_the_command() {
+    helpers::check_diagnostics(
+        r#"
+//- /backend.rs
+#[tauri::command]
+fn gre$0et() {}
+
+//- /frontend.ts
+import { invoke } from "@tauri-apps/api/core";
+
+const call = (name: string, args: unknown) => invoke(name, args);
+
+export const greetSomeone = (who: string) => call("greet", { name: who });
 "#,
         expect!["(none)"],
     );
@@ -734,6 +795,8 @@ fn gre$0et() {}
 import { invoke } from "@tauri-apps/api/core";
 
 const call = (name: string) => invoke(name);
+
+export const callAny = (name: string) => call(name);
 "#,
         expect!["(none)"],
     );

--- a/lsp-server/tests/diagnostics_tests.rs
+++ b/lsp-server/tests/diagnostics_tests.rs
@@ -663,3 +663,160 @@ listen("$0weather", (e) => {});
         ]],
     );
 }
+
+// ===========================================================================
+// Dynamic (unresolved) names — see `indexer::DynamicUsages`
+// ===========================================================================
+
+#[test]
+fn diag_local_binding_does_not_resolve_to_foreign_constant() {
+    // `event` is a parameter, so it must not pick up the same-named object key
+    // declared in an unrelated file — that would index a "click" event nobody wrote.
+    helpers::check_diagnostics(
+        r#"
+//- /widget.ts
+const defaults = { event: "click" };
+
+//- /sync.ts
+import { emitTo } from "@tauri-apps/api/event";
+
+const emitToOverlays = async (event: string, payload: unknown) => {
+  await emitTo("overlay", ev$0ent, payload);
+};
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_dynamic_emit_suppresses_never_emitted() {
+    // The event name reaches `emitTo` through a wrapper parameter, so the emit
+    // cannot be attributed and "never emitted" can no longer be proven.
+    helpers::check_diagnostics(
+        r#"
+//- /sync.ts
+import { emitTo, listen } from "@tauri-apps/api/event";
+
+const emitToOverlays = async (event: string, payload: unknown) => {
+  await emitTo("overlay", event, payload);
+};
+
+listen("$0units-changed", () => {});
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_dynamic_listen_suppresses_no_listeners() {
+    helpers::check_diagnostics(
+        r#"
+//- /sync.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+const subscribe = (event: string) => listen(event, () => {});
+
+emit("$0units-changed");
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_dynamic_invoke_suppresses_unused_command() {
+    helpers::check_diagnostics(
+        r#"
+//- /backend.rs
+#[tauri::command]
+fn gre$0et() {}
+
+//- /frontend.ts
+import { invoke } from "@tauri-apps/api/core";
+
+const call = (name: string) => invoke(name);
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_dynamic_rust_emit_suppresses_never_emitted() {
+    helpers::check_diagnostics(
+        r#"
+//- /backend.rs
+fn broadcast(app: &AppHandle, name: &str) {
+    app.emit(name, ()).unwrap();
+}
+
+//- /frontend.ts
+import { listen } from "@tauri-apps/api/event";
+listen("$0units-changed", () => {});
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_static_emit_still_warns_alongside_unrelated_dynamic_invoke() {
+    // A dynamic *invoke* says nothing about listeners, so event diagnostics stay on.
+    helpers::check_diagnostics(
+        r#"
+//- /frontend.ts
+import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
+
+const call = (name: string) => invoke(name);
+
+emit("$0my-event");
+"#,
+        expect![[r#"WARNING 5:6..5:14 "Event 'my-event' is emitted but no listeners found""#]],
+    );
+}
+
+#[test]
+fn diag_empty_literal_is_not_a_dynamic_name() {
+    // `invoke("")` names nothing, but it is fully known — it must not suppress
+    // the unused-command warning the way an unresolvable name does.
+    helpers::check_diagnostics(
+        r#"
+//- /backend.rs
+#[tauri::command]
+fn gre$0et() {}
+
+//- /frontend.ts
+import { invoke } from "@tauri-apps/api/core";
+invoke("");
+"#,
+        expect![[r#"WARNING 1:3..1:8 "Command 'greet' is defined but never invoked in frontend""#]],
+    );
+}
+
+#[test]
+fn diag_empty_event_literal_is_not_a_dynamic_name() {
+    helpers::check_diagnostics(
+        r#"
+//- /frontend.ts
+import { emit, listen } from "@tauri-apps/api/event";
+listen("", () => {});
+emit("$0my-event");
+"#,
+        expect![[r#"WARNING 2:6..2:14 "Event 'my-event' is emitted but no listeners found""#]],
+    );
+}
+
+#[test]
+fn diag_empty_rust_event_literal_is_not_a_dynamic_name() {
+    helpers::check_diagnostics(
+        r#"
+//- /backend.rs
+fn noop(app: &AppHandle) {
+    app.emit("", ()).unwrap();
+}
+
+//- /frontend.ts
+import { listen } from "@tauri-apps/api/event";
+listen("$0units-changed", () => {});
+"#,
+        expect![[r#"WARNING 1:8..1:21 "Event 'units-changed' is listened for but never emitted""#]],
+    );
+}

--- a/lsp-server/tests/helpers.rs
+++ b/lsp-server/tests/helpers.rs
@@ -179,8 +179,12 @@ pub fn parse_fixture(input: &str) -> FixtureData {
                 }
             }
         } else {
-            let parse_result =
-                tree_parser::parse(&path, &content, &std::collections::HashMap::new());
+            let parse_result = tree_parser::parse(
+                &path,
+                &content,
+                &std::collections::HashMap::new(),
+                &std::collections::HashMap::new(),
+            );
             match parse_result {
                 Ok(file_index) => {
                     index.add_file(file_index);
@@ -192,6 +196,26 @@ pub fn parse_fixture(input: &str) -> FixtureData {
         }
 
         contents.insert(path, content);
+    }
+
+    // Second pass: forwarding helpers are cross-file, so a call site can only be
+    // resolved once every file has contributed its declarations. Mirrors the
+    // pre-pass the real pipeline runs before indexing.
+    let known_forwarders = index.get_all_forwarders();
+
+    for (path, content) in &contents {
+        if path.extension().is_some_and(|ext| ext == "rs") {
+            continue;
+        }
+
+        if let Ok(file_index) = tree_parser::parse(
+            path,
+            content,
+            &std::collections::HashMap::new(),
+            &known_forwarders,
+        ) {
+            index.add_file(file_index);
+        }
     }
 
     // Apply $SCHEMA directives
@@ -413,8 +437,12 @@ pub fn check_parse(fixture: &str, expect: Expect) {
 
     for file_path in &files {
         let content = &data.contents[file_path];
-        let parse_result =
-            tree_parser::parse(file_path, content, &std::collections::HashMap::new());
+        let parse_result = tree_parser::parse(
+            file_path,
+            content,
+            &std::collections::HashMap::new(),
+            &data.index.get_all_forwarders(),
+        );
 
         match parse_result {
             Ok(file_index) => {

--- a/lsp-server/tests/indexer_tests.rs
+++ b/lsp-server/tests/indexer_tests.rs
@@ -4,8 +4,8 @@ mod common_paths;
 
 use common_paths::test_path;
 use lsp_server::indexer::{
-    CommandSchema, EventSchema, FileIndex, Finding, GeneratorKind, IndexKey, ParamSchema,
-    ProjectIndex,
+    CommandSchema, DynamicUsages, EventSchema, FileIndex, Finding, GeneratorKind, IndexKey,
+    ParamSchema, ProjectIndex,
 };
 use lsp_server::syntax::{Behavior, EntityType};
 use tower_lsp_server::lsp_types::{Position, Range};
@@ -46,6 +46,7 @@ fn test_add_file_to_index() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     index.add_file(file_index);
@@ -67,6 +68,7 @@ fn test_remove_file_from_index() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     index.add_file(file_index);
@@ -97,6 +99,7 @@ fn test_get_locations() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     // Add frontend command call
@@ -107,6 +110,7 @@ fn test_get_locations() {
             EntityType::Command,
             Behavior::Call,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     index.add_file(backend_file);
@@ -152,6 +156,7 @@ fn test_get_key_at_position() {
     let file_index = FileIndex {
         path: path.clone(),
         findings: vec![finding],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     index.add_file(file_index);
@@ -183,6 +188,7 @@ fn test_get_diagnostic_info() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     // Add a command call
@@ -193,6 +199,7 @@ fn test_get_diagnostic_info() {
             EntityType::Command,
             Behavior::Call,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
 
     index.add_file(backend_file);
@@ -220,6 +227,7 @@ fn test_multiple_files_same_command() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     });
 
     // Add multiple calls from different files
@@ -230,6 +238,7 @@ fn test_multiple_files_same_command() {
             EntityType::Command,
             Behavior::Call,
         )],
+        dynamic_usages: DynamicUsages::default(),
     });
 
     index.add_file(FileIndex {
@@ -239,6 +248,7 @@ fn test_multiple_files_same_command() {
             EntityType::Command,
             Behavior::Call,
         )],
+        dynamic_usages: DynamicUsages::default(),
     });
 
     let locations = index.get_locations(EntityType::Command, "get_user");
@@ -308,6 +318,7 @@ fn test_schema_survives_file_map_remove() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     });
 
     // Add a schema from bindings
@@ -373,6 +384,7 @@ fn test_stale_rust_command_schema_cleared_on_reparse() {
             EntityType::Command,
             Behavior::Definition,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
     index.add_file(file_index);
     index.add_schema(CommandSchema {
@@ -390,6 +402,7 @@ fn test_stale_rust_command_schema_cleared_on_reparse() {
     let file_index = FileIndex {
         path: path.clone(),
         findings: vec![],
+        dynamic_usages: DynamicUsages::default(),
     };
     index.add_file(file_index);
 
@@ -412,6 +425,7 @@ fn test_stale_rust_event_schema_cleared_on_reparse() {
             EntityType::Event,
             Behavior::Emit,
         )],
+        dynamic_usages: DynamicUsages::default(),
     };
     index.add_file(file_index);
     index.add_event_schema(EventSchema {
@@ -428,6 +442,7 @@ fn test_stale_rust_event_schema_cleared_on_reparse() {
     let file_index = FileIndex {
         path: path.clone(),
         findings: vec![],
+        dynamic_usages: DynamicUsages::default(),
     };
     index.add_file(file_index);
 

--- a/lsp-server/tests/indexer_tests.rs
+++ b/lsp-server/tests/indexer_tests.rs
@@ -47,6 +47,7 @@ fn test_add_file_to_index() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     index.add_file(file_index);
@@ -69,6 +70,7 @@ fn test_remove_file_from_index() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     index.add_file(file_index);
@@ -100,6 +102,7 @@ fn test_get_locations() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     // Add frontend command call
@@ -111,6 +114,7 @@ fn test_get_locations() {
             Behavior::Call,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     index.add_file(backend_file);
@@ -157,6 +161,7 @@ fn test_get_key_at_position() {
         path: path.clone(),
         findings: vec![finding],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     index.add_file(file_index);
@@ -189,6 +194,7 @@ fn test_get_diagnostic_info() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     // Add a command call
@@ -200,6 +206,7 @@ fn test_get_diagnostic_info() {
             Behavior::Call,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
 
     index.add_file(backend_file);
@@ -228,6 +235,7 @@ fn test_multiple_files_same_command() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     });
 
     // Add multiple calls from different files
@@ -239,6 +247,7 @@ fn test_multiple_files_same_command() {
             Behavior::Call,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     });
 
     index.add_file(FileIndex {
@@ -249,6 +258,7 @@ fn test_multiple_files_same_command() {
             Behavior::Call,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     });
 
     let locations = index.get_locations(EntityType::Command, "get_user");
@@ -319,6 +329,7 @@ fn test_schema_survives_file_map_remove() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     });
 
     // Add a schema from bindings
@@ -385,6 +396,7 @@ fn test_stale_rust_command_schema_cleared_on_reparse() {
             Behavior::Definition,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
     index.add_file(file_index);
     index.add_schema(CommandSchema {
@@ -403,6 +415,7 @@ fn test_stale_rust_command_schema_cleared_on_reparse() {
         path: path.clone(),
         findings: vec![],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
     index.add_file(file_index);
 
@@ -426,6 +439,7 @@ fn test_stale_rust_event_schema_cleared_on_reparse() {
             Behavior::Emit,
         )],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
     index.add_file(file_index);
     index.add_event_schema(EventSchema {
@@ -443,6 +457,7 @@ fn test_stale_rust_event_schema_cleared_on_reparse() {
         path: path.clone(),
         findings: vec![],
         dynamic_usages: DynamicUsages::default(),
+        forwarders: Vec::new(),
     };
     index.add_file(file_index);
 

--- a/lsp-server/tests/parse_tests.rs
+++ b/lsp-server/tests/parse_tests.rs
@@ -384,8 +384,13 @@ fn parse_vue_single_script() {
     )
     .unwrap();
     let path = std::path::PathBuf::from("/test/component.vue");
-    let result =
-        lsp_server::tree_parser::parse(&path, &content, &std::collections::HashMap::new()).unwrap();
+    let result = lsp_server::tree_parser::parse(
+        &path,
+        &content,
+        &std::collections::HashMap::new(),
+        &std::collections::HashMap::new(),
+    )
+    .unwrap();
 
     let mut out = String::new();
     let mut findings = result.findings;
@@ -426,8 +431,13 @@ fn parse_vue_multiple_scripts() {
     )
     .unwrap();
     let path = std::path::PathBuf::from("/test/multi.vue");
-    let result =
-        lsp_server::tree_parser::parse(&path, &content, &std::collections::HashMap::new()).unwrap();
+    let result = lsp_server::tree_parser::parse(
+        &path,
+        &content,
+        &std::collections::HashMap::new(),
+        &std::collections::HashMap::new(),
+    )
+    .unwrap();
     assert!(
         !result.findings.is_empty(),
         "Expected findings in Vue multi-script"
@@ -445,8 +455,13 @@ fn parse_svelte_component() {
     )
     .unwrap();
     let path = std::path::PathBuf::from("/test/component.svelte");
-    let result =
-        lsp_server::tree_parser::parse(&path, &content, &std::collections::HashMap::new()).unwrap();
+    let result = lsp_server::tree_parser::parse(
+        &path,
+        &content,
+        &std::collections::HashMap::new(),
+        &std::collections::HashMap::new(),
+    )
+    .unwrap();
     assert!(
         !result.findings.is_empty(),
         "Expected findings in Svelte component"
@@ -629,8 +644,13 @@ listen(SIM_DISCONNECTED, (event) => {});
         lsp_server::utils::extract_js_constants_from_content(constants_content, false);
 
     // Pass 2: parse the consumer file with global constants
-    let result = lsp_server::tree_parser::parse(&component_path, component_content, &js_constants)
-        .expect("parse should succeed");
+    let result = lsp_server::tree_parser::parse(
+        &component_path,
+        component_content,
+        &js_constants,
+        &std::collections::HashMap::new(),
+    )
+    .expect("parse should succeed");
 
     let mut findings = result.findings;
     findings.sort_by_key(|f| f.range.start.line);
@@ -854,5 +874,125 @@ export default Counter;
         expect![[r#"
             /Counter.tsx:
               Command Call "increment" 8:37..8:46"#]],
+    );
+}
+
+#[test]
+fn parse_ts_forwarded_event_indexed_at_call_site() {
+    // The `emitTo` inside the helper yields no finding of its own; the call site
+    // does, which is what makes goto-definition and CodeLens reach the other side.
+    helpers::check_parse(
+        r#"
+//- /sync.ts
+import { emitTo } from "@tauri-apps/api/event";
+
+const emitToOverlays = async (event: string, payload: unknown) => {
+  await emitTo("overlay", event, payload);
+};
+
+export const emitUnits = (value: string) => emitToOverlays("units-changed", value);
+export const emitDrag = (active: boolean) => emitToOverlays("drag-mode-changed", active);
+"#,
+        expect![[r#"
+            /sync.ts:
+              Event Emit "units-changed" 6:60..6:73
+              Event Emit "drag-mode-changed" 7:61..7:78"#]],
+    );
+}
+
+#[test]
+fn parse_ts_forwarded_event_across_files() {
+    helpers::check_parse(
+        r#"
+//- /emit-helpers.ts
+import { emit } from "@tauri-apps/api/event";
+
+export const broadcast = (event: string, payload: unknown) => emit(event, payload);
+
+//- /app.ts
+import { broadcast } from "./emit-helpers";
+
+broadcast("units-changed", "metric");
+"#,
+        expect![[r#"
+            /app.ts:
+              Event Emit "units-changed" 2:11..2:24"#]],
+    );
+}
+
+#[test]
+fn parse_ts_ambiguous_forwarder_name_is_not_resolved() {
+    // Two files declare `broadcast` with the name in a different argument slot.
+    // Without following imports there is no way to tell which one `app.ts` calls,
+    // so neither is applied rather than guessing and indexing the wrong event.
+    helpers::check_parse(
+        r#"
+//- /emit-first.ts
+import { emit } from "@tauri-apps/api/event";
+
+export const broadcast = (event: string, payload: unknown) => emit(event, payload);
+
+//- /emit-second.ts
+import { emitTo } from "@tauri-apps/api/event";
+
+export const broadcast = (target: string, event: string) => emitTo(target, event);
+
+//- /app.ts
+import { broadcast } from "./emit-first";
+
+broadcast("units-changed", "metric");
+"#,
+        expect![[r#""#]],
+    );
+}
+
+#[test]
+fn parse_ts_forwarded_command_indexed_at_call_site() {
+    helpers::check_parse(
+        r#"
+//- /api.ts
+import { invoke } from "@tauri-apps/api/core";
+
+const call = (name: string, args: unknown) => invoke(name, args);
+
+export const greetSomeone = (who: string) => call("greet", { name: who });
+"#,
+        expect![[r#"
+            /api.ts:
+              Command Call "greet" 4:51..4:56"#]],
+    );
+}
+
+#[test]
+fn parse_ts_fan_out_helper_resolves_every_call_site() {
+    // Shape taken from a real project: a private async helper loops over window
+    // labels and forwards its `event` parameter into `emitTo`.
+    helpers::check_parse(
+        r#"
+//- /events.ts
+import { emit, emitTo, listen } from "@tauri-apps/api/event";
+
+const emitToOverlays = async (event: string, payload: unknown) => {
+  const labels = await listOverlayWindowLabels();
+
+  for (const label of labels) {
+    await emitTo(label, event, payload);
+  }
+};
+
+export const emitUnitsChanged = (system: string) =>
+  emitToOverlays("units-changed", system);
+
+export const emitSteeringLockChanged = (degrees: number) =>
+  emitToOverlays("steering-lock-changed", degrees);
+
+export const emitStandingsScroll = (delta: number) =>
+  emitToOverlays("standings-scroll", delta);
+"#,
+        expect![[r#"
+            /events.ts:
+              Event Emit "units-changed" 11:18..11:31
+              Event Emit "steering-lock-changed" 14:18..14:39
+              Event Emit "standings-scroll" 17:18..17:34"#]],
     );
 }

--- a/lsp-server/tests/parse_tests.rs
+++ b/lsp-server/tests/parse_tests.rs
@@ -145,6 +145,28 @@ async function fetchData() {
 }
 
 #[test]
+fn parse_ts_template_literal_names() {
+    helpers::check_parse(
+        r#"
+//- /app.ts
+import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
+
+async function run(suffix: string) {
+    await invoke(`get_user`, { id: 42 });
+    await emit(`ready`);
+    // Interpolated names are genuinely dynamic and must stay unresolved.
+    await invoke(`get_${suffix}`);
+}
+"#,
+        expect![[r#"
+            /app.ts:
+              Command Call "get_user" 4:18..4:26
+              Event Emit "ready" 5:16..5:21"#]],
+    );
+}
+
+#[test]
 fn parse_ts_no_tauri_import() {
     helpers::check_parse(
         r#"


### PR DESCRIPTION
Resolve invoke/emit/listen names against local bindings before workspace constants, so a parameter no longer picks up an unrelated file's value. Track call sites whose name cannot be resolved to a literal and suppress absence diagnostics for the matching kind, since they assume a closed world.