### PR TITLE
fix(parser): resolve forwarder calls written as `await helper<T>(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change Log
 
+### [Unreleased]
+
+- **Bug fixes**
+  - Fixed wrapper functions not being resolved when the call is both awaited and given an explicit type argument (`await listenTo<Payload>("event", ...)`). Such a call was skipped, so every event the helper subscribed to was reported as having no listeners
+
 ### [0.12.0] - 2026-07-29
 
 - **Bug fixes**

--- a/lsp-server/src/queries/typescript.scm
+++ b/lsp-server/src/queries/typescript.scm
@@ -297,3 +297,14 @@
   function: (identifier) @plain_fn
   arguments: (arguments) @plain_args
 )
+
+; `await helper<T>(...)` parses with the await *inside* the callee:
+;   (call_expression function: (await_expression (identifier)) type_arguments: ...)
+; The plain `await helper(...)` does not — it nests the other way round. Without
+; this pattern an awaited generic call never reaches the forwarder resolver, and
+; every event the helper subscribes to looks like it has no listener.
+(call_expression
+  function: (await_expression
+    (identifier) @plain_fn)
+  arguments: (arguments) @plain_args
+)

--- a/lsp-server/tests/diagnostics_tests.rs
+++ b/lsp-server/tests/diagnostics_tests.rs
@@ -748,6 +748,61 @@ emit("$0units-changed");
 }
 
 #[test]
+fn diag_generic_forwarded_listen_reaches_the_emitter() {
+    // Same helper as above, called with an explicit type argument. The type
+    // argument changes nothing about which parameter carries the event name, so
+    // the call site has to resolve exactly as the plain one does.
+    helpers::check_diagnostics(
+        r#"
+//- /sync.ts
+import { emit, listen } from "@tauri-apps/api/event";
+
+const subscribe = <T>(event: string) => listen(event, (_e: T) => {});
+
+export const watchUnits = () => subscribe<boolean>("units-changed");
+
+emit("$0units-changed");
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
+fn diag_awaited_generic_forwarded_listen_reaches_the_emitter() {
+    // `await helper<T>(...)` puts the await inside the callee, so the helper
+    // name is not directly under `function:`. The helper is declared in another
+    // module here because that is the shape this was reported against.
+    helpers::check_diagnostics(
+        r#"
+//- /services/events.service.ts
+import { listen, type EventCallback, type UnlistenFn } from "@tauri-apps/api/event";
+
+export const listenTo = <PayloadType>(
+  event: string,
+  handler: EventCallback<PayloadType>
+): Promise<UnlistenFn> => listen(event, handler);
+
+//- /store/sync/events.ts
+import { emit } from "@tauri-apps/api/event";
+import { listenTo } from "../../services/events.service";
+
+export const setupOverlayListeners = async () => {
+  const unlistens: UnlistenFn[] = [];
+
+  unlistens.push(
+    await listenTo<boolean>("units-changed", () => {})
+  );
+
+  return unlistens;
+};
+
+export const emitUnitsChanged = (value: boolean) => emit("$0units-changed", value);
+"#,
+        expect!["(none)"],
+    );
+}
+
+#[test]
 fn diag_dynamic_listen_suppresses_no_listeners() {
     helpers::check_diagnostics(
         r#"


### PR DESCRIPTION
Fixed wrapper functions not being resolved when the call is both awaited and
      given an explicit type argument (`await listenTo<Payload>("event", ...)`).
      Such a call was skipped, so every event the helper subscribed to was reported
      as having no listeners